### PR TITLE
chore: fix usage and error msg

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_create_llm.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_llm.md
@@ -22,13 +22,13 @@ kbcli cluster create llm NAME [flags]
 
 ```
       --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
-      --cpu float                    CPU cores. Value range [0.5, 64]. (default 2)
+      --cpu float                    CPU cores. Value range [0, 64].
       --cpu-mode                     Set to true if no GPU is available
       --extra-args string            extra arguments that will be passed to run model (default "--trust-remote-code")
       --gpu float                    GPU cores. Value range [0, 64]. (default 1)
   -h, --help                         help for llm
       --host-network-accessible      Specify whether the cluster can be accessed from within the VPC.
-      --memory float                 Memory, the unit is Gi. Value range [0.5, 1000]. (default 6)
+      --memory float                 Memory, the unit is Gi. Value range [0, 1000].
       --model string                 Model name (default "facebook/opt-125m")
       --monitoring-interval int      The monitoring interval of cluster, 0 is disabled, the unit is second. Value range [0, 60].
       --publicly-accessible          Specify whether the cluster can be accessed from the public internet.

--- a/docs/user_docs/cli/kbcli_clusterdefinition_list-service-reference.md
+++ b/docs/user_docs/cli/kbcli_clusterdefinition_list-service-reference.md
@@ -12,7 +12,7 @@ kbcli clusterdefinition list-service-reference [flags]
 
 ```
   # List cluster references name declared in a cluster definition.
-  kbcli clusterdefinition list-service-reference apecloud-mysql
+  kbcli clusterdefinition list-service-reference orioledb
 ```
 
 ### Options

--- a/pkg/cmd/cluster/create.go
+++ b/pkg/cmd/cluster/create.go
@@ -1763,7 +1763,7 @@ func getServiceRefs(serviceRef []string, cd *appsv1alpha1.ClusterDefinition) ([]
 			}
 			if !valid {
 				// todo:  kbcli cluster list-serviceRef
-				return nil, fmt.Errorf("the service reference name \"%s\" is not declared in the cluster components,use `kbcli cluster list-serviceRef %s` to show all available service reference names", serviceRefName, cd.Name)
+				return nil, fmt.Errorf("the service reference name \"%s\" is not declared in the cluster-definition %s ,use `kbcli clusterdefinition list-serviceRef %s` to show all available service reference names", serviceRefName, cd.Name, cd.Name)
 			}
 		}
 		serviceRefSets = append(serviceRefSets, refMap)

--- a/pkg/cmd/clusterdefinition/list_service_reference.go
+++ b/pkg/cmd/clusterdefinition/list_service_reference.go
@@ -40,7 +40,7 @@ import (
 var (
 	listServiceRefExample = templates.Examples(`
 		# List cluster references name declared in a cluster definition.
-		kbcli clusterdefinition list-service-reference apecloud-mysql`)
+		kbcli clusterdefinition list-service-reference orioledb`)
 )
 
 func NewListServiceReferenceCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
fix `kbcli clusterdefinition list-service-reference` usage and `kbcli cluster create` error msg  