### PR TITLE
chore: support reconfigure operation for multi components (#5906)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ bin
 testbin/*
 __debug_bin
 
+pkg/cluster/charts/*.tgz
+
 output
 helm-output
 

--- a/docs/user_docs/cli/kbcli_cluster_custom-ops.md
+++ b/docs/user_docs/cli/kbcli_cluster_custom-ops.md
@@ -1,39 +1,39 @@
 ---
-title: kbcli cluster configure
+title: kbcli cluster custom-ops
 ---
 
-Configure parameters with the specified components in the cluster.
+
 
 ```
-kbcli cluster configure NAME --set key=value[,key=value] [--components=component1-name,component2-name] [--config-spec=config-spec-name] [--config-file=config-file] [flags]
+kbcli cluster custom-ops OpsDef --cluster <clusterName> <your custom params> [flags]
 ```
 
 ### Examples
 
 ```
-  # update component params
-  kbcli cluster configure mycluster --component=mysql --config-spec=mysql-3node-tpl --config-file=my.cnf --set max_connections=1000,general_log=OFF
+  # custom ops cli format
+  kbcli cluster custom-ops <opsDefName> --cluster <clusterName> <your params of this opsDef>
   
-  # if only one component, and one config spec, and one config file, simplify the searching process of configure. e.g:
-  # update mysql max_connections, cluster name is mycluster
-  kbcli cluster configure mycluster --set max_connections=2000
+  # example for kafka topic
+  kbcli cluster custom-ops kafka-topic --cluster mycluster --type create --topic test --partition 3 --replicas 3
+  
+  # example for kafka acl
+  kbcli cluster custom-ops kafka-user-acl --cluster mycluster --type add --operations "Read,Writer,Delete,Alter,Describe" --allowUsers client --topic "*"
+  
+  # example for kafka quota
+  kbcli cluster custom-ops kafka-quota --cluster mycluster --user client --producerByteRate 1024 --consumerByteRate 2048
 ```
 
 ### Options
 
 ```
-      --auto-approve                   Skip interactive approval before reconfiguring the cluster
-      --components strings             Component names to this operations
-      --config-file string             Specify the name of the configuration file to be updated (e.g. for mysql: --config-file=my.cnf). For available templates and configs, refer to: 'kbcli cluster describe-config'.
-      --config-spec string             Specify the name of the configuration template to be updated (e.g. for apecloud-mysql: --config-spec=mysql-3node-tpl). For available templates and configs, refer to: 'kbcli cluster describe-config'.
+      --auto-approve                   Skip interactive approval before promote the instance
+      --cluster string                 Specify the cluster name
+      --component string               Specify the component name of the cluster. if not specified, using the first component which referenced the defined componentDefinition.
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
-      --force-restart                  Boolean flag to restart component. Default with false.
-  -h, --help                           help for configure
-      --local-file string              Specify the local configuration file to be updated.
+  -h, --help                           help for custom-ops
       --name string                    OpsRequest name. if not specified, it will be randomly generated 
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
-      --replace                        Boolean flag to enable replacing config file. Default with false.
-      --set strings                    Specify parameters list to be updated. For more details, refer to 'kbcli cluster describe-config'.
       --ttlSecondsAfterSucceed int     Time to live after the OpsRequest succeed
 ```
 
@@ -47,7 +47,6 @@ kbcli cluster configure NAME --set key=value[,key=value] [--components=component
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure

--- a/docs/user_docs/cli/kbcli_cluster_edit-config.md
+++ b/docs/user_docs/cli/kbcli_cluster_edit-config.md
@@ -18,7 +18,7 @@ kbcli cluster edit-config NAME [--component=component-name] [--config-spec=confi
 ### Options
 
 ```
-      --component string               Specify the name of Component to be updated. If the cluster has only one component, unset the parameter.
+      --components strings             Component names to this operations
       --config-file string             Specify the name of the configuration file to be updated (e.g. for mysql: --config-file=my.cnf). For available templates and configs, refer to: 'kbcli cluster describe-config'.
       --config-spec string             Specify the name of the configuration template to be updated (e.g. for apecloud-mysql: --config-spec=mysql-3node-tpl). For available templates and configs, refer to: 'kbcli cluster describe-config'.
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")

--- a/pkg/action/template/cluster_operations_template.cue
+++ b/pkg/action/template/cluster_operations_template.cue
@@ -125,24 +125,49 @@ content: {
 			}]
 		}
 		if options.type == "Reconfiguring" {
-			reconfigure: {
-				componentName: options.componentNames[0]
-				configurations: [ {
-					name: options.cfgTemplateName
-					if options.forceRestart {
-						policy: "simple"
-					}
-					keys: [{
-						key: options.cfgFile
-						if options.fileContent != "" {
-							fileContent: options.fileContent
+			if len(options.componentNames) == 1 {
+				reconfigure: {
+					componentName: options.componentNames[0]
+					configurations: [ {
+						name: options.cfgTemplateName
+						if options.forceRestart {
+							policy: "simple"
 						}
-						if options.hasPatch {
-							parameters: [ for k, v in options.keyValues {
-								key:   k
-								value: v
-							}]
+						keys: [{
+							key: options.cfgFile
+							if options.fileContent != "" {
+								fileContent: options.fileContent
+							}
+							if options.hasPatch {
+								parameters: [ for k, v in options.keyValues {
+									key:   k
+									value: v
+								}]
+							}
+						}]
+					}]
+				}
+			}
+			if len(options.componentNames) > 1 {
+				reconfigures: [ for _, cName in options.componentNames {
+					componentName: cName
+					configurations: [ {
+						name: options.cfgTemplateName
+						if options.forceRestart {
+							policy: "simple"
 						}
+						keys: [{
+							key: options.cfgFile
+							if options.fileContent != "" {
+								fileContent: options.fileContent
+							}
+							if options.hasPatch {
+								parameters: [ for k, v in options.keyValues {
+									key:   k
+									value: v
+								}]
+							}
+						}]
 					}]
 				}]
 			}

--- a/pkg/cmd/cluster/config_edit.go
+++ b/pkg/cmd/cluster/config_edit.go
@@ -228,7 +228,7 @@ func NewEditConfigureCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) 
 	o := &editConfigOptions{
 		configOpsOptions: configOpsOptions{
 			editMode:          true,
-			OperationsOptions: newBaseOperationsOptions(f, streams, appsv1alpha1.ReconfiguringType, false),
+			OperationsOptions: newBaseOperationsOptions(f, streams, appsv1alpha1.ReconfiguringType, true),
 		}}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/cluster/config_ops.go
+++ b/pkg/cmd/cluster/config_ops.go
@@ -39,7 +39,6 @@ import (
 	"github.com/apecloud/kbcli/pkg/printer"
 	"github.com/apecloud/kbcli/pkg/types"
 	"github.com/apecloud/kbcli/pkg/util"
-	"github.com/apecloud/kbcli/pkg/util/flags"
 	"github.com/apecloud/kbcli/pkg/util/prompt"
 )
 
@@ -72,6 +71,10 @@ var (
 func (o *configOpsOptions) Complete() error {
 	if o.Name == "" {
 		return makeMissingClusterNameErr()
+	}
+
+	if len(o.ComponentNames) > 0 {
+		o.ComponentName = o.ComponentNames[0]
 	}
 
 	if !o.editMode {
@@ -117,7 +120,9 @@ func (o *configOpsOptions) Validate() error {
 
 	o.CfgFile = o.wrapper.ConfigFile()
 	o.CfgTemplateName = o.wrapper.ConfigSpecName()
-	o.ComponentNames = []string{o.wrapper.ComponentName()}
+	if len(o.ComponentNames) == 0 {
+		o.ComponentNames = []string{o.wrapper.ComponentName()}
+	}
 
 	if o.editMode {
 		return nil
@@ -241,7 +246,7 @@ func (o *configOpsOptions) buildReconfigureCommonFlags(cmd *cobra.Command, f cmd
 		"For available templates and configs, refer to: 'kbcli cluster describe-config'.")
 	cmd.Flags().StringVar(&o.CfgFile, "config-file", "", "Specify the name of the configuration file to be updated (e.g. for mysql: --config-file=my.cnf). "+
 		"For available templates and configs, refer to: 'kbcli cluster describe-config'.")
-	flags.AddComponentFlag(f, cmd, &o.ComponentName, "Specify the name of Component to be updated. If the cluster has only one component, unset the parameter.")
+	// flags.AddComponentFlag(f, cmd, &o.ComponentName, "Specify the name of Component to be updated. If the cluster has only one component, unset the parameter.")
 	cmd.Flags().BoolVar(&o.ForceRestart, "force-restart", false, "Boolean flag to restart component. Default with false.")
 	cmd.Flags().StringVar(&o.LocalFilePath, "local-file", "", "Specify the local configuration file to be updated.")
 	cmd.Flags().BoolVar(&o.replaceFile, "replace", false, "Boolean flag to enable replacing config file. Default with false.")
@@ -251,10 +256,10 @@ func (o *configOpsOptions) buildReconfigureCommonFlags(cmd *cobra.Command, f cmd
 func NewReconfigureCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := &configOpsOptions{
 		editMode:          false,
-		OperationsOptions: newBaseOperationsOptions(f, streams, appsv1alpha1.ReconfiguringType, false),
+		OperationsOptions: newBaseOperationsOptions(f, streams, appsv1alpha1.ReconfiguringType, true),
 	}
 	cmd := &cobra.Command{
-		Use:               "configure NAME --set key=value[,key=value] [--component=component-name] [--config-spec=config-spec-name] [--config-file=config-file]",
+		Use:               "configure NAME --set key=value[,key=value] [--components=component1-name,component2-name] [--config-spec=config-spec-name] [--config-file=config-file]",
 		Short:             "Configure parameters with the specified components in the cluster.",
 		Example:           createReconfigureExample,
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, types.ClusterGVR()),


### PR DESCRIPTION
**Simplify reconfigure operation of clickhouse and mongodb multi-sharding engines**

feat: [[Features] reconfigure operation support multi components #5906](https://github.com/apecloud/kubeblocks/issues/5906)

related pr: https://github.com/apecloud/kubeblocks/pull/5994

e.g: kbcli cluster edit-config ch --components=shard-0,shard-1,shard-2