### PR TITLE
chore: kb install/upgrade handle version with v prefix

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_create_llm.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_llm.md
@@ -22,20 +22,22 @@ kbcli cluster create llm NAME [flags]
 
 ```
       --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
-      --cpu float                    CPU cores. Value range [0.5, 64]. (default 2)
+      --cpu float                    CPU cores. Value range [0, 64].
       --cpu-mode                     Set to true if no GPU is available
       --extra-args string            extra arguments that will be passed to run model (default "--trust-remote-code")
       --gpu float                    GPU cores. Value range [0, 64]. (default 1)
   -h, --help                         help for llm
       --host-network-accessible      Specify whether the cluster can be accessed from within the VPC.
-      --memory float                 Memory, the unit is Gi. Value range [0.5, 1000]. (default 6)
+      --memory float                 Memory, the unit is Gi. Value range [0, 1000].
       --model string                 Model name (default "facebook/opt-125m")
       --monitoring-interval int      The monitoring interval of cluster, 0 is disabled, the unit is second. Value range [0, 60].
       --publicly-accessible          Specify whether the cluster can be accessed from the public internet.
+      --quantize string              Model's quantized file name, only work for CPU mode
       --rbac-enabled                 Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --replicas int                 The number of replicas, for standalone mode, the replicas is 1, for replication mode, the default replicas is 2. Value range [1, 5]. (default 1)
       --tenancy string               The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
       --termination-policy string    The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
+      --url string                   Model URL, only work for CPU mode
       --version string               Cluster version.
 ```
 

--- a/pkg/cmd/auth/login.go
+++ b/pkg/cmd/auth/login.go
@@ -246,7 +246,7 @@ func getFirstContext(token string, orgName string) string {
 		return ""
 	}
 
-	if contexts != nil && len(contexts) > 0 {
+	if len(contexts) > 0 {
 		return contexts[0].Name
 	}
 	return ""

--- a/pkg/cmd/kubeblocks/install.go
+++ b/pkg/cmd/kubeblocks/install.go
@@ -227,6 +227,7 @@ func (o *InstallOptions) PreCheck() error {
 		return err
 	}
 
+	o.Version = util.TrimVersionPrefix(o.Version)
 	if err = o.checkVersion(v); err != nil {
 		return err
 	}

--- a/pkg/cmd/kubeblocks/upgrade.go
+++ b/pkg/cmd/kubeblocks/upgrade.go
@@ -99,6 +99,7 @@ func (o *InstallOptions) Upgrade() error {
 		o.HelmCfg.SetNamespace(ns)
 	}
 
+	o.Version = util.TrimVersionPrefix(o.Version)
 	// check flags already been set
 	if o.Version == "" && helm.ValueOptsIsEmpty(&o.ValueOpts) {
 		fmt.Fprint(o.Out, "Nothing to upgrade, --set, --version should be specified.\n")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1043,3 +1043,11 @@ func RandRFC1123String(n int) string {
 	}
 	return string(b)
 }
+
+func TrimVersionPrefix(version string) string {
+	version = strings.TrimSpace(version)
+	if len(version) > 0 && (version[0] == 'v' || version[0] == 'V') {
+		return version[1:]
+	}
+	return version
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -328,4 +328,35 @@ var _ = Describe("util", func() {
 		Expect(podAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].Weight).ShouldNot(BeNil())
 		Expect(podAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey).Should(Equal(topologyKey))
 	})
+
+	It("test trim version prefix", func() {
+		testCases := []struct {
+			version  string
+			expected string
+		}{
+			{
+				version:  "v1.20.0",
+				expected: "1.20.0",
+			},
+			{
+				version:  "v1.20.0-beta.0",
+				expected: "1.20.0-beta.0",
+			},
+			{
+				version:  "V1.20.0",
+				expected: "1.20.0",
+			},
+			{
+				version:  "1.20.0",
+				expected: "1.20.0",
+			},
+			{
+				version:  "",
+				expected: "",
+			},
+		}
+		for _, tc := range testCases {
+			Expect(TrimVersionPrefix(tc.version)).Should(Equal(tc.expected))
+		}
+	})
 })


### PR DESCRIPTION
* fix https://github.com/apecloud/kubeblocks/issues/5943