### PR TITLE
fix: fix image.registry env not be persisted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/spf13/cast v1.5.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.16.0
 	github.com/stoewer/go-strcase v1.2.0
 	github.com/stretchr/testify v1.8.4
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -297,7 +298,6 @@ require (
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/viper v1.16.0 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/sylabs/sif/v2 v2.11.5 // indirect

--- a/pkg/cmd/addon/addon.go
+++ b/pkg/cmd/addon/addon.go
@@ -703,9 +703,17 @@ func (o *addonCmdOpts) buildHelmPatch(result map[string]interface{}) error {
 		helmSpec = *o.addon.Spec.Helm
 		helmSpec.InstallValues.SetValues = o.addonEnableFlags.SetValues
 	}
-	// set resource registry
-	if viper.Get(types.CfgKeyImageRegistry) != "" {
-		helmSpec.InstallValues.SetValues = append(helmSpec.InstallValues.SetValues, fmt.Sprintf("%s=%s", types.ImageRegistryKey, viper.Get(types.CfgKeyImageRegistry)))
+	// use default KB registry source
+	declared := false
+	for _, s := range helmSpec.InstallValues.SetValues {
+		if split := strings.Split(s, "="); split[0] == types.ImageRegistryKey && len(split) == 2 {
+			declared = true
+			break
+		}
+	}
+
+	if defaultRegistry := viper.Get(types.CfgKeyImageRegistry); !declared && defaultRegistry != nil && defaultRegistry != "" {
+		helmSpec.InstallValues.SetValues = append(helmSpec.InstallValues.SetValues, fmt.Sprintf("%s=%s", types.ImageRegistryKey, defaultRegistry))
 	}
 
 	b, err := json.Marshal(&helmSpec)

--- a/pkg/cmd/cluster/operations.go
+++ b/pkg/cmd/cluster/operations.go
@@ -33,7 +33,6 @@ import (
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1046,7 +1045,7 @@ func (o *customOperations) parseOpsDefinitionAndParams(cmd *cobra.Command, args 
 		return fmt.Errorf("please specify the custom ops which you want to do")
 	}
 	_ = flags.NewTmpFlagSet()
-	return flags.BuildFlagsWithOpenAPISchema(cmd, args, func() (*v1.JSONSchemaProps, error) {
+	return flags.BuildFlagsWithOpenAPISchema(cmd, args, func() (*apiextensionsv1.JSONSchemaProps, error) {
 		o.OpsDefinitionName = args[0]
 		// Get ops Definition from API server
 		opsDef := &appsv1alpha1.OpsDefinition{}

--- a/pkg/cmd/kubeblocks/install.go
+++ b/pkg/cmd/kubeblocks/install.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/preflight"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"golang.org/x/exp/maps"
 	"helm.sh/helm/v3/pkg/cli/values"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,7 +48,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 
 	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
-	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+	viperx "github.com/apecloud/kubeblocks/pkg/viperx"
 
 	"github.com/apecloud/kbcli/pkg/spinner"
 	"github.com/apecloud/kbcli/pkg/types"
@@ -292,10 +294,25 @@ func (o *InstallOptions) Install() error {
 		return err
 	}
 	// save KB image.registry config
+	writeImageRegistryKey := func(registry string) error {
+		viperx.Set(types.CfgKeyImageRegistry, registry)
+		v := viperx.GetViper()
+		err := v.WriteConfig()
+		if errors.As(err, &viper.ConfigFileNotFoundError{}) {
+			dir, err := util.GetCliHomeDir()
+			if err != nil {
+				return err
+			}
+			return viper.WriteConfigAs(filepath.Join(dir, "config.yaml"))
+		}
+		return err
+	}
+
 	for _, s := range o.ValueOpts.Values {
 		if split := strings.Split(s, "="); split[0] == types.ImageRegistryKey && len(split) == 2 {
-			viper.Set(types.CfgKeyImageRegistry, split[1])
-			break
+			if err := writeImageRegistryKey(split[1]); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
- fix https://github.com/apecloud/kubeblocks/issues/6120

fix two promble:
1.  viper env not be persisted
2. viper.Get will return nil when the key not be found