### PR TITLE
feat: Support upate parameters in non-default sections, e.g client or mysql: --set mysql.default-character-set = utf8mb4 (#6453)

### DIFF
--- a/pkg/cmd/cluster/config_edit.go
+++ b/pkg/cmd/cluster/config_edit.go
@@ -144,7 +144,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 		}
 	}
 
-	params := core.GenerateVisualizedParamsList(configPatch, configConstraint.Spec.FormatterConfig, nil)
+	params := core.GenerateVisualizedParamsListImpl(configPatch, configConstraint.Spec.FormatterConfig, nil, true)
 	// check immutable parameters
 	if len(configConstraint.Spec.ImmutableParameters) > 0 {
 		if err = util.ValidateParametersModified2(sets.KeySet(fromKeyValuesToMap(params, o.CfgFile)), configConstraint.Spec); err != nil {


### PR DESCRIPTION
depend kubeblocks pr: https://github.com/apecloud/kubeblocks/pull/6634