### PR TITLE
feat: edit-backup-policy supports backup encryption configuration

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_edit-backup-policy.md
+++ b/docs/user_docs/cli/kbcli_cluster_edit-backup-policy.md
@@ -14,8 +14,14 @@ kbcli cluster edit-backup-policy
   # edit backup policy
   kbcli cluster edit-backup-policy <backup-policy-name>
   
-  # update backup Repo
+  # specify a backup repository
   kbcli cluster edit-backup-policy <backup-policy-name> --set backupRepoName=<backup-repo-name>
+  
+  # enable encryption
+  kbcli cluster edit-backup-policy <backup-policy-name> --set encryption.algorithm=AES-256-CFB --set encryption.passPhrase="SECRET!"
+  
+  # disable encryption
+  kbcli cluster edit-backup-policy <backup-policy-name> --set encryption.disabled=true
   
   # using short cmd to edit backup policy
   kbcli cluster edit-bp <backup-policy-name>

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/99designs/keyring v1.2.2
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/apecloud/kubebench v0.0.0-20240103064917-92a20332c817
-	github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240301065417-ed5bf6c8a4b2
+	github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240305040354-fcd1aa88ecde
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/benbjohnson/clock v1.3.5
 	github.com/briandowns/spinner v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/99designs/keyring v1.2.2
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/apecloud/kubebench v0.0.0-20240103064917-92a20332c817
-	github.com/apecloud/kubeblocks v0.9.0-alpha.2
+	github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240301065417-ed5bf6c8a4b2
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/benbjohnson/clock v1.3.5
 	github.com/briandowns/spinner v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -272,10 +272,8 @@ github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/apecloud/kubebench v0.0.0-20240103064917-92a20332c817 h1:BAaK2sQ24aQCBWf0LaU7X8bRAH8a0CKQ5ohNiieM4us=
 github.com/apecloud/kubebench v0.0.0-20240103064917-92a20332c817/go.mod h1:4/MxAKYxQMRTFXCr2zZGviwy1PgNtJo5H8VF6jdF/PU=
-github.com/apecloud/kubeblocks v0.9.0-alpha.2 h1:UiBx89AOAAGSGz0iKUjNq8TaTphu53/EuyjNrCxWOHc=
-github.com/apecloud/kubeblocks v0.9.0-alpha.2/go.mod h1:Rl8VABmwW/Cf7vyodu1qIpoEpHXqGegh4XsP18U5zsg=
-github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240301065417-ed5bf6c8a4b2 h1:FcxO9oNOlqJuLYGLkYO7HBYMcV3o63GdiAFDKYauvhs=
-github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240301065417-ed5bf6c8a4b2/go.mod h1:Rl8VABmwW/Cf7vyodu1qIpoEpHXqGegh4XsP18U5zsg=
+github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240305040354-fcd1aa88ecde h1:UQ56VPtrrUU8mvVJgCczrPCLhrZM2P3sSwKUnD/hI/o=
+github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240305040354-fcd1aa88ecde/go.mod h1:Rl8VABmwW/Cf7vyodu1qIpoEpHXqGegh4XsP18U5zsg=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/apecloud/kubebench v0.0.0-20240103064917-92a20332c817 h1:BAaK2sQ24aQC
 github.com/apecloud/kubebench v0.0.0-20240103064917-92a20332c817/go.mod h1:4/MxAKYxQMRTFXCr2zZGviwy1PgNtJo5H8VF6jdF/PU=
 github.com/apecloud/kubeblocks v0.9.0-alpha.2 h1:UiBx89AOAAGSGz0iKUjNq8TaTphu53/EuyjNrCxWOHc=
 github.com/apecloud/kubeblocks v0.9.0-alpha.2/go.mod h1:Rl8VABmwW/Cf7vyodu1qIpoEpHXqGegh4XsP18U5zsg=
+github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240301065417-ed5bf6c8a4b2 h1:FcxO9oNOlqJuLYGLkYO7HBYMcV3o63GdiAFDKYauvhs=
+github.com/apecloud/kubeblocks v0.9.0-alpha.2.0.20240301065417-ed5bf6c8a4b2/go.mod h1:Rl8VABmwW/Cf7vyodu1qIpoEpHXqGegh4XsP18U5zsg=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/cmd/builder/template/component_wrapper.go
+++ b/pkg/cmd/builder/template/component_wrapper.go
@@ -331,7 +331,7 @@ func generateComponentObjects(w *templateRenderWorkflow, reqCtx intctrlutil.Requ
 	model.NewGraphClient(nil).Root(dag, nil, root, nil)
 
 	compSpec := cluster.Spec.GetComponentByName(compName)
-	comp, err := component.BuildComponent(cluster, compSpec, nil)
+	comp, err := component.BuildComponent(cluster, compSpec, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cmd/cluster/dataprotection.go
+++ b/pkg/cmd/cluster/dataprotection.go
@@ -73,17 +73,17 @@ var (
 		# edit backup policy
 		kbcli cluster edit-backup-policy <backup-policy-name>
 
-        # specify a backup repository
+		# specify a backup repository
 		kbcli cluster edit-backup-policy <backup-policy-name> --set backupRepoName=<backup-repo-name>
 
-        # enable encryption
+		# enable encryption
 		kbcli cluster edit-backup-policy <backup-policy-name> --set encryption.algorithm=AES-256-CFB --set encryption.passPhrase="SECRET!"
 
-        # disable encryption
+		# disable encryption
 		kbcli cluster edit-backup-policy <backup-policy-name> --set encryption.disabled=true
 
-	    # using short cmd to edit backup policy
-        kbcli cluster edit-bp <backup-policy-name>
+		# using short cmd to edit backup policy
+		kbcli cluster edit-bp <backup-policy-name>
 	`)
 	createBackupExample = templates.Examples(`
 		# Create a backup for the cluster, use the default backup policy and volume snapshot backup method


### PR DESCRIPTION
Ref: https://github.com/apecloud/kubeblocks/pull/6723

Usage:
```
  # enable encryption
  kbcli cluster edit-backup-policy <backup-policy-name> --set encryption.algorithm=AES-256-CFB --set encryption.passPhrase="SECRET!"
  
  # disable encryption
  kbcli cluster edit-backup-policy <backup-policy-name> --set encryption.disabled=true
```