### PR TITLE
fix: Raise the version constraint of KBCLI and KB (#300)

### DIFF
--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -21,6 +21,7 @@ package version
 
 import (
 	"fmt"
+	"reflect"
 	"runtime"
 
 	gv "github.com/hashicorp/go-version"
@@ -90,5 +91,5 @@ func (o *versionOptions) Run(f cmdutil.Factory) {
 }
 
 func checkVersionMatch(cliVersion *gv.Version, kbVersion *gv.Version) bool {
-	return cliVersion.Segments64()[0] == kbVersion.Segments64()[0] && cliVersion.Segments64()[1] == kbVersion.Segments64()[1]
+	return reflect.DeepEqual(cliVersion.Segments64(), kbVersion.Segments64())
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -84,11 +84,11 @@ func (o *versionOptions) Run(f cmdutil.Factory) {
 		return
 	}
 
-	if !CheckVersionMatch(kbVersion, cliVersion) {
+	if !checkVersionMatch(kbVersion, cliVersion) {
 		fmt.Printf("WARNING: version difference between kbcli (%s) and kubeblocks (%s) \n", v.Cli, v.KubeBlocks)
 	}
 }
 
-func CheckVersionMatch(cliVersion *gv.Version, kbVersion *gv.Version) bool {
+func checkVersionMatch(cliVersion *gv.Version, kbVersion *gv.Version) bool {
 	return cliVersion.Segments64()[0] == kbVersion.Segments64()[0] && cliVersion.Segments64()[1] == kbVersion.Segments64()[1]
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -84,7 +84,11 @@ func (o *versionOptions) Run(f cmdutil.Factory) {
 		return
 	}
 
-	if !kbVersion.Equal(cliVersion) {
+	if !CheckVersionMatch(kbVersion, cliVersion) {
 		fmt.Printf("WARNING: version difference between kbcli (%s) and kubeblocks (%s) \n", v.Cli, v.KubeBlocks)
 	}
+}
+
+func CheckVersionMatch(cliVersion *gv.Version, kbVersion *gv.Version) bool {
+	return cliVersion.Segments64()[0] == kbVersion.Segments64()[0] && cliVersion.Segments64()[1] == kbVersion.Segments64()[1]
 }

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -58,4 +58,18 @@ var _ = Describe("version", func() {
 		cliVersion, _ = gv.NewVersion("v0.6.3")
 		Expect(kbVersion.Equal(cliVersion)).Should(BeTrue())
 	})
+
+	It("version match", func() {
+		kbVersion, _ := gv.NewVersion("0.6.0-alpha.23")
+		cliVersion, _ := gv.NewVersion("0.6.1-alpha.23")
+		Expect(CheckVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
+
+		kbVersion, _ = gv.NewVersion("0.6.0-alpha.23")
+		cliVersion, _ = gv.NewVersion("v0.6.23")
+		Expect(CheckVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
+
+		kbVersion, _ = gv.NewVersion("0.7.0-alpha.23")
+		cliVersion, _ = gv.NewVersion("0.6.0-beta.23")
+		Expect(CheckVersionMatch(cliVersion, kbVersion)).Should(BeFalse())
+	})
 })

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -62,14 +62,14 @@ var _ = Describe("version", func() {
 	It("version match", func() {
 		kbVersion, _ := gv.NewVersion("0.6.0-alpha.23")
 		cliVersion, _ := gv.NewVersion("0.6.1-alpha.23")
-		Expect(CheckVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
+		Expect(checkVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
 
 		kbVersion, _ = gv.NewVersion("0.6.0-alpha.23")
 		cliVersion, _ = gv.NewVersion("v0.6.23")
-		Expect(CheckVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
+		Expect(checkVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
 
 		kbVersion, _ = gv.NewVersion("0.7.0-alpha.23")
 		cliVersion, _ = gv.NewVersion("0.6.0-beta.23")
-		Expect(CheckVersionMatch(cliVersion, kbVersion)).Should(BeFalse())
+		Expect(checkVersionMatch(cliVersion, kbVersion)).Should(BeFalse())
 	})
 })

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -62,14 +62,14 @@ var _ = Describe("version", func() {
 	It("version match", func() {
 		kbVersion, _ := gv.NewVersion("0.6.0-alpha.23")
 		cliVersion, _ := gv.NewVersion("0.6.1-alpha.23")
-		Expect(checkVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
+		Expect(checkVersionMatch(cliVersion, kbVersion)).Should(BeFalse())
 
 		kbVersion, _ = gv.NewVersion("0.6.0-alpha.23")
-		cliVersion, _ = gv.NewVersion("v0.6.23")
+		cliVersion, _ = gv.NewVersion("v0.6.0-beta.17")
 		Expect(checkVersionMatch(cliVersion, kbVersion)).Should(BeTrue())
 
 		kbVersion, _ = gv.NewVersion("0.7.0-alpha.23")
-		cliVersion, _ = gv.NewVersion("0.6.0-beta.23")
+		cliVersion, _ = gv.NewVersion("0.6-beta.23")
 		Expect(checkVersionMatch(cliVersion, kbVersion)).Should(BeFalse())
 	})
 })


### PR DESCRIPTION
fix #300 