### PR TITLE
fix: kbcli uninstall kubeblocks fail (#7646)

### DIFF
--- a/pkg/cmd/kubeblocks/kubeblocks_objects.go
+++ b/pkg/cmd/kubeblocks/kubeblocks_objects.go
@@ -262,11 +262,8 @@ func checkAndPatchCCRequiredFields(dynamic dynamic.Interface, object *unstructur
 	}
 
 	_, found, err := unstructured.NestedString(object.Object, "spec", "fileFormatConfig", "format")
-	if err != nil {
+	if err != nil || found {
 		return err
-	}
-	if found {
-		return nil
 	}
 
 	patchBytes, _ := json.Marshal(patchData)

--- a/pkg/cmd/kubeblocks/util.go
+++ b/pkg/cmd/kubeblocks/util.go
@@ -67,7 +67,10 @@ func getGVRByCRD(crd *unstructured.Unstructured) (*schema.GroupVersionResource, 
 
 func getVersionFromCRD(crd *unstructured.Unstructured) string {
 	versions, found, err := unstructured.NestedFieldNoCopy(crd.Object, "spec", "versions")
-	if err != nil || !found {
+	if err != nil || !found || versions == nil {
+		return types.AppsAPIVersion
+	}
+	if _, ok := versions.([]interface{}); !ok {
 		return types.AppsAPIVersion
 	}
 


### PR DESCRIPTION
After the upgrade, the storage version of configconstraint will be adjusted to v1beta1. When kubeblocks uninstall is deleted, the deletion of the v1alpha1 version will trigger apiserver multi version conversion. Because the webhook is not enabled, the fields of the converted v1beta1 version will be missing.