### PR TITLE
fix: update default k3s version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ goimports: goimportstool ## Run goimports against code.
 
 
 ##@ CLI
-K3S_VERSION ?= v1.23.8+k3s1
+K3S_VERSION ?= v1.30.2+k3s2
 K3D_VERSION ?= 5.4.4
 K3S_IMG_TAG ?= $(subst +,-,$(K3S_VERSION))
 FETCH_ADDON_ENABLED ?= true


### PR DESCRIPTION
Command `kbcli playground init` depends on this variable, a newer version of k8s cluster can avoid errors caused by outdated fields in addon Helm charts during kubeblocks installation.
fix #397 #196 