### PR TITLE
fix: playground  init command waits cd and cv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/go-logr/logr v1.4.1
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hc-install v0.5.2
 	github.com/hashicorp/terraform-exec v0.18.0
 	github.com/jedib0t/go-pretty/v6 v6.4.6

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,6 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
-github.com/apecloud/kubeblocks v0.9.0-beta.32 h1:DUztOHGW17ceN0etYMdYIj8dUK1MPCXX+gkd2CUf6XM=
-github.com/apecloud/kubeblocks v0.9.0-beta.32/go.mod h1:kp9nenBgXsO03SbxN7a5S2HdNTsIQlpTcSgY8Mf2KS0=
 github.com/apecloud/kubeblocks v0.9.1-beta.6 h1:/7k80XnLzJxhW+CaUgiIThm6JlCto+giNqscl6fKU6s=
 github.com/apecloud/kubeblocks v0.9.1-beta.6/go.mod h1:kp9nenBgXsO03SbxN7a5S2HdNTsIQlpTcSgY8Mf2KS0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
@@ -753,8 +751,9 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -2101,8 +2100,6 @@ k8s.io/cli-runtime v0.28.3/go.mod h1:jeX37ZPjIcENVuXDDTskG3+FnVuZms5D9omDXS/2Jjc
 k8s.io/client-go v0.28.3 h1:2OqNb72ZuTZPKCl+4gTKvqao0AMOl9f3o2ijbAj3LI4=
 k8s.io/client-go v0.28.3/go.mod h1:LTykbBp9gsA7SwqirlCXBWtK0guzfhpoW4qSm7i9dxo=
 k8s.io/code-generator v0.28.3/go.mod h1:A2EAHTRYvCvBrb/MM2zZBNipeCk3f8NtpdNIKawC43M=
-k8s.io/component-base v0.28.3 h1:rDy68eHKxq/80RiMb2Ld/tbH8uAE75JdCqJyi6lXMzI=
-k8s.io/component-base v0.28.3/go.mod h1:fDJ6vpVNSk6cRo5wmDa6eKIG7UlIQkaFmZN2fYgIUD8=
 k8s.io/component-base v0.29.0 h1:T7rjd5wvLnPBV1vC4zWd/iWRbV8Mdxs+nGaoaFzGw3s=
 k8s.io/component-base v0.29.0/go.mod h1:sADonFTQ9Zc9yFLghpDpmNXEdHyQmFIGbiuZbqAXQ1M=
 k8s.io/component-helpers v0.28.3 h1:te9ieTGzcztVktUs92X53P6BamAoP73MK0qQP0WmDqc=

--- a/pkg/cmd/cluster/create.go
+++ b/pkg/cmd/cluster/create.go
@@ -318,7 +318,7 @@ func NewCreateCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 	registerFlagCompletionFunc(cmd, f)
 
 	// add all subcommands for supported cluster type
-	cmd.AddCommand(buildCreateSubCmds(&o.CreateOptions)...)
+	cmd.AddCommand(BuildCreateSubCmds(&o.CreateOptions)...)
 
 	o.Cmd = cmd
 

--- a/pkg/cmd/cluster/create_subcmds.go
+++ b/pkg/cmd/cluster/create_subcmds.go
@@ -68,7 +68,7 @@ func NewSubCmdsOptions(createOptions *action.CreateOptions, t cluster.ClusterTyp
 	return o, nil
 }
 
-func buildCreateSubCmds(createOptions *action.CreateOptions) []*cobra.Command {
+func BuildCreateSubCmds(createOptions *action.CreateOptions) []*cobra.Command {
 	var cmds []*cobra.Command
 
 	for _, t := range cluster.SupportedTypes() {
@@ -86,8 +86,8 @@ func buildCreateSubCmds(createOptions *action.CreateOptions) []*cobra.Command {
 			Run: func(cmd *cobra.Command, args []string) {
 				o.Args = args
 				cmdutil.CheckErr(o.CreateOptions.Complete())
-				cmdutil.CheckErr(o.complete(cmd))
-				cmdutil.CheckErr(o.validate())
+				cmdutil.CheckErr(o.Complete(cmd))
+				cmdutil.CheckErr(o.Validate())
 				cmdutil.CheckErr(o.Run())
 			},
 		}
@@ -102,7 +102,7 @@ func buildCreateSubCmds(createOptions *action.CreateOptions) []*cobra.Command {
 	return cmds
 }
 
-func (o *CreateSubCmdsOptions) complete(cmd *cobra.Command) error {
+func (o *CreateSubCmdsOptions) Complete(cmd *cobra.Command) error {
 	var err error
 
 	// if name is not specified, generate a random cluster name
@@ -154,7 +154,7 @@ func (o *CreateSubCmdsOptions) complete(cmd *cobra.Command) error {
 	return nil
 }
 
-func (o *CreateSubCmdsOptions) validate() error {
+func (o *CreateSubCmdsOptions) Validate() error {
 	return cluster.ValidateValues(o.ChartInfo, o.Values)
 }
 

--- a/pkg/cmd/cluster/create_subcmds_test.go
+++ b/pkg/cmd/cluster/create_subcmds_test.go
@@ -86,7 +86,7 @@ var _ = Describe("create cluster by cluster type", func() {
 
 	It("create mysql cluster command", func() {
 		By("create commands")
-		cmds := buildCreateSubCmds(createOptions)
+		cmds := BuildCreateSubCmds(createOptions)
 		Expect(cmds).ShouldNot(BeNil())
 		Expect(cmds[0].HasFlags()).Should(BeTrue())
 
@@ -110,14 +110,14 @@ var _ = Describe("create cluster by cluster type", func() {
 		o.Client = testing.FakeClientSet()
 		fakeDiscovery1, _ := o.Client.Discovery().(*fakediscovery.FakeDiscovery)
 		fakeDiscovery1.FakedServerVersion = &version.Info{Major: "1", Minor: "27", GitVersion: "v1.27.0"}
-		Expect(o.complete(mysqlCmd)).Should(Succeed())
+		Expect(o.Complete(mysqlCmd)).Should(Succeed())
 		Expect(o.Name).ShouldNot(BeEmpty())
 		Expect(o.Values).ShouldNot(BeNil())
 		Expect(o.ChartInfo.ClusterDef).Should(Equal(apeCloudMysql))
 
 		By("validate")
 		o.Dynamic = testing.FakeDynamicClient()
-		Expect(o.validate()).Should(Succeed())
+		Expect(o.Validate()).Should(Succeed())
 
 		By("run")
 		o.DryRun = "client"


### PR DESCRIPTION
When we use `kbcli playground init` command, add the following code logic:
* wait clusterDefinition to be found after addons enabled.
* If kubeblocks version is greater than `1.0.0-alpha.0`, use `create subcommand` to create cluster. Assume clusterVersion is not defined if can not be found in 30s and use `create subcommand` to create cluster as well. Otherwise, clusterVersion would be waited and use `create command` to create cluster.