### PR TITLE
fix: add restriction when upgrade addon from 0.8 to 0.9

### DIFF
--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -71,7 +71,7 @@ type PatchOptions struct {
 	fieldManager                 string
 
 	EditBeforeUpdate bool
-
+	SkipPatch        bool
 	genericiooptions.IOStreams
 }
 
@@ -125,6 +125,10 @@ func (o *PatchOptions) complete() error {
 func (o *PatchOptions) Run() error {
 	if err := o.complete(); err != nil {
 		return err
+	}
+
+	if o.SkipPatch {
+		return nil
 	}
 
 	if len(o.Patch) == 0 {

--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -71,6 +71,7 @@ type PatchOptions struct {
 	fieldManager                 string
 
 	EditBeforeUpdate bool
+
 	genericiooptions.IOStreams
 }
 

--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -71,7 +71,6 @@ type PatchOptions struct {
 	fieldManager                 string
 
 	EditBeforeUpdate bool
-	SkipPatch        bool
 	genericiooptions.IOStreams
 }
 
@@ -125,10 +124,6 @@ func (o *PatchOptions) complete() error {
 func (o *PatchOptions) Run() error {
 	if err := o.complete(); err != nil {
 		return err
-	}
-
-	if o.SkipPatch {
-		return nil
 	}
 
 	if len(o.Patch) == 0 {

--- a/pkg/cmd/addon/addon.go
+++ b/pkg/cmd/addon/addon.go
@@ -363,7 +363,7 @@ func (o *addonCmdOpts) validate() error {
 }
 
 func checkBreakingChange(o *addonCmdOpts) error {
-	if o.addonEnableFlags.noChange() {
+	if o.addonEnableFlags.noChange() && o.addon.Status.Phase == extensionsv1alpha1.AddonEnabled {
 		return nil
 	}
 	client, err := o.Factory.KubernetesClientSet()

--- a/pkg/cmd/addon/addon.go
+++ b/pkg/cmd/addon/addon.go
@@ -790,11 +790,6 @@ func (o *addonCmdOpts) buildPatch(flags []*pflag.Flag) error {
 	helm := map[string]interface{}{}
 
 	if o.addonEnableFlags != nil {
-		// skip patching if no change detected, to avoid breaking change
-		if o.addonEnableFlags.noChange() && o.addon.Status.Phase == extensionsv1alpha1.AddonEnabled {
-			o.PatchOptions.SkipPatch = true
-			return nil
-		}
 		if o.addon.Status.Phase == extensionsv1alpha1.AddonFailed {
 			status["phase"] = nil
 		}

--- a/pkg/util/breakingchange/upgrader.go
+++ b/pkg/util/breakingchange/upgrader.go
@@ -36,8 +36,9 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/apecloud/kbcli/pkg/printer"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+
+	"github.com/apecloud/kbcli/pkg/printer"
 )
 
 var upgradeHandlerMapper = map[string]upgradeHandlerRecorder{}
@@ -169,8 +170,8 @@ func ValidatePatchUpgradeVersion(out io.Writer, name, kbVersion, addonVersion st
 		return false
 	}
 	if !kb.LessThan(version09) && (addon.LessThan(version09) || isIrregularVersion()) {
-		printer.Warning(out, `%s-%s upgrade is not compatible with KubeBlocks %s, you can specify "--force" to upgrade%s`, name, addonVersion, kbVersion, "\n")
-		return fmt.Errorf("this upgrade may cause unexpected errors, it's not recommended to upgrade. ")
+		printer.Warning(out, `%s-%s is not compatible with KubeBlocks %s, you should run "kbcli addon upgrade %s" first%s`, name, addonVersion, kbVersion, name, "\n")
+		return fmt.Errorf(`this enable operation may cause unexpected errors, you can specify "--force" to enable.`)
 	}
 	return nil
 }

--- a/pkg/util/breakingchange/upgrader.go
+++ b/pkg/util/breakingchange/upgrader.go
@@ -171,7 +171,7 @@ func ValidatePatchUpgradeVersion(out io.Writer, name, kbVersion, addonVersion st
 	}
 	if !kb.LessThan(version09) && (addon.LessThan(version09) || isIrregularVersion()) {
 		printer.Warning(out, `%s-%s is not compatible with KubeBlocks %s, you should run "kbcli addon upgrade %s" first%s`, name, addonVersion, kbVersion, name, "\n")
-		return fmt.Errorf(`this enable operation may cause unexpected errors, you can specify "--force" to enable.`)
+		return fmt.Errorf(`this enable operation may cause unexpected errors, you can specify "--force" to enable`)
 	}
 	return nil
 }


### PR DESCRIPTION
- resolved https://github.com/apecloud/kubeblocks/issues/7982

assume the situation that addon version is 0.8 and kb version was upgrade from 0.8 to 0.9

1. add a validation in order to check this situation and return a warning, but which can also be exculated by "--force".
2. consider that user could disable and enable addon, this scenario will also hit this bug, event flag not set, we should give a warning when simply enable 0.8 addon