### PR TITLE
bugfix: support create sharding cluster

### DIFF
--- a/pkg/cmd/cluster/create_subcmds.go
+++ b/pkg/cmd/cluster/create_subcmds.go
@@ -147,9 +147,10 @@ func (o *CreateSubCmdsOptions) complete(cmd *cobra.Command) error {
 	if shardingSpec, ok := spec["shardingSpecs"].([]interface{}); ok {
 		for i := range shardingSpec {
 			shard := shardingSpec[i].(map[string]interface{})
-			compSpec := shard["template"].(map[string]interface{})
-			if compDef, ok := compSpec["componentDef"]; ok {
-				o.ChartInfo.ComponentDef = append(o.ChartInfo.ComponentDef, compDef.(string))
+			if compSpec, ok := shard["template"].(map[string]interface{}); ok {
+				if compDef, ok := compSpec["componentDef"]; ok {
+					o.ChartInfo.ComponentDef = append(o.ChartInfo.ComponentDef, compDef.(string))
+				}
 			}
 		}
 	}

--- a/pkg/cmd/cluster/create_subcmds.go
+++ b/pkg/cmd/cluster/create_subcmds.go
@@ -133,13 +133,22 @@ func (o *CreateSubCmdsOptions) complete(cmd *cobra.Command) error {
 	if !ok {
 		return fmt.Errorf("cannot find spec in cluster object")
 	}
+	if o.ChartInfo.ComponentDef == nil {
+		o.ChartInfo.ComponentDef = []string{}
+	}
 	if compSpec, ok := spec["componentSpecs"].([]interface{}); ok {
-		if o.ChartInfo.ComponentDef == nil {
-			o.ChartInfo.ComponentDef = []string{}
-		}
 		for i := range compSpec {
 			comp := compSpec[i].(map[string]interface{})
 			if compDef, ok := comp["componentDef"]; ok {
+				o.ChartInfo.ComponentDef = append(o.ChartInfo.ComponentDef, compDef.(string))
+			}
+		}
+	}
+	if shardingSpec, ok := spec["shardingSpecs"].([]interface{}); ok {
+		for i := range shardingSpec {
+			shard := shardingSpec[i].(map[string]interface{})
+			compSpec := shard["template"].(map[string]interface{})
+			if compDef, ok := compSpec["componentDef"]; ok {
 				o.ChartInfo.ComponentDef = append(o.ChartInfo.ComponentDef, compDef.(string))
 			}
 		}
@@ -148,7 +157,7 @@ func (o *CreateSubCmdsOptions) complete(cmd *cobra.Command) error {
 		o.ChartInfo.ClusterDef = clusterDef
 	}
 	if o.ChartInfo.ClusterDef == "" && len(o.ChartInfo.ComponentDef) == 0 {
-		return fmt.Errorf("cannot find clusterDefinitionRef in cluster spec or componentDef in componentSpecs")
+		return fmt.Errorf("cannot find clusterDefinitionRef in cluster spec or componentDef in componentSpecs or shardingSpecs")
 	}
 
 	return nil


### PR DESCRIPTION
fix #428

Change
- Support verifying componnetDef from shardingSpecs of the cluster.

Test
- After fixed, a redis cluster with mode "cluster" can be created correctly.

1. Edit go build configuration.
<img width="536" alt="image" src="https://github.com/user-attachments/assets/4b3dde2f-7da8-4cd8-a350-356fcf3bdd7a">

2. Run the kbcli with commands and get result.
<img width="233" alt="image" src="https://github.com/user-attachments/assets/91f2b7d4-4146-4e8e-8a8f-c922f5c19233">

3. Check the phase of redis cluster.
<img width="826" alt="image" src="https://github.com/user-attachments/assets/c48736ba-a958-42b2-9db7-bf6d1400b247">

