### PR TITLE
fix: support create sharding cluster

### DIFF
--- a/pkg/cmd/cluster/create_subcmds.go
+++ b/pkg/cmd/cluster/create_subcmds.go
@@ -133,10 +133,10 @@ func (o *CreateSubCmdsOptions) complete(cmd *cobra.Command) error {
 	if !ok {
 		return fmt.Errorf("cannot find spec in cluster object")
 	}
+	if o.ChartInfo.ComponentDef == nil {
+		o.ChartInfo.ComponentDef = []string{}
+	}
 	if compSpec, ok := spec["componentSpecs"].([]interface{}); ok {
-		if o.ChartInfo.ComponentDef == nil {
-			o.ChartInfo.ComponentDef = []string{}
-		}
 		for i := range compSpec {
 			comp := compSpec[i].(map[string]interface{})
 			if compDef, ok := comp["componentDef"]; ok {
@@ -144,11 +144,21 @@ func (o *CreateSubCmdsOptions) complete(cmd *cobra.Command) error {
 			}
 		}
 	}
+	if shardingSpec, ok := spec["shardingSpecs"].([]interface{}); ok {
+		for i := range shardingSpec {
+			shard := shardingSpec[i].(map[string]interface{})
+			if compSpec, ok := shard["template"].(map[string]interface{}); ok {
+				if compDef, ok := compSpec["componentDef"]; ok {
+					o.ChartInfo.ComponentDef = append(o.ChartInfo.ComponentDef, compDef.(string))
+				}
+			}
+		}
+	}
 	if clusterDef, ok := spec["clusterDefinitionRef"].(string); ok {
 		o.ChartInfo.ClusterDef = clusterDef
 	}
 	if o.ChartInfo.ClusterDef == "" && len(o.ChartInfo.ComponentDef) == 0 {
-		return fmt.Errorf("cannot find clusterDefinitionRef in cluster spec or componentDef in componentSpecs")
+		return fmt.Errorf("cannot find clusterDefinitionRef in cluster spec or componentDef in componentSpecs or shardingSpecs")
 	}
 
 	return nil

--- a/pkg/cmd/cluster/create_subcmds_test.go
+++ b/pkg/cmd/cluster/create_subcmds_test.go
@@ -47,7 +47,9 @@ import (
 
 var _ = Describe("create cluster by cluster type", func() {
 	const (
-		clusterType = "apecloud-mysql"
+		clusterType    = "apecloud-mysql"
+		redisCluster   = "redis"
+		redisComponent = "redis-cluster-7"
 	)
 
 	var (
@@ -114,6 +116,52 @@ var _ = Describe("create cluster by cluster type", func() {
 		Expect(o.Name).ShouldNot(BeEmpty())
 		Expect(o.Values).ShouldNot(BeNil())
 		Expect(o.ChartInfo.ClusterDef).Should(Equal(apeCloudMysql))
+
+		By("validate")
+		o.Dynamic = testing.FakeDynamicClient()
+		Expect(o.validate()).Should(Succeed())
+
+		By("run")
+		o.DryRun = "client"
+		o.Client = testing.FakeClientSet()
+		fakeDiscovery, _ := o.Client.Discovery().(*fakediscovery.FakeDiscovery)
+		fakeDiscovery.FakedServerVersion = &version.Info{Major: "1", Minor: "27", GitVersion: "v1.27.0"}
+		Expect(o.Run()).Should(Succeed())
+	})
+
+	It("create sharding cluster command", func() {
+		By("create commands")
+		cmds := buildCreateSubCmds(createOptions)
+		Expect(cmds).ShouldNot(BeNil())
+		Expect(cmds[0].HasFlags()).Should(BeTrue())
+
+		By("create command options")
+		o, err := NewSubCmdsOptions(createOptions, redisCluster)
+		Expect(err).Should(Succeed())
+		Expect(o).ShouldNot(BeNil())
+		Expect(o.ChartInfo).ShouldNot(BeNil())
+
+		By("complete")
+		var shardCmd *cobra.Command
+		for _, c := range cmds {
+			if c.Name() == redisCluster {
+				shardCmd = c
+				break
+			}
+		}
+
+		o.Format = printer.YAML
+		Expect(o.CreateOptions.Complete()).Should(Succeed())
+		o.DryRun = "client"
+		o.Client = testing.FakeClientSet()
+		fakeDiscovery1, _ := o.Client.Discovery().(*fakediscovery.FakeDiscovery)
+		fakeDiscovery1.FakedServerVersion = &version.Info{Major: "1", Minor: "27", GitVersion: "v1.27.0"}
+
+		shardCmd.Flags().Set("mode", "cluster")
+		Expect(o.complete(shardCmd)).Should(Succeed())
+		Expect(o.Name).ShouldNot(BeEmpty())
+		Expect(o.Values).ShouldNot(BeNil())
+		Expect(o.ChartInfo.ComponentDef[0]).Should(Equal(redisComponent))
 
 		By("validate")
 		o.Dynamic = testing.FakeDynamicClient()

--- a/pkg/cmd/cluster/create_subcmds_test.go
+++ b/pkg/cmd/cluster/create_subcmds_test.go
@@ -157,7 +157,7 @@ var _ = Describe("create cluster by cluster type", func() {
 		fakeDiscovery1, _ := o.Client.Discovery().(*fakediscovery.FakeDiscovery)
 		fakeDiscovery1.FakedServerVersion = &version.Info{Major: "1", Minor: "27", GitVersion: "v1.27.0"}
 
-		shardCmd.Flags().Set("mode", "cluster")
+		Expect(shardCmd.Flags().Set("mode", "cluster")).Should(Succeed())
 		Expect(o.complete(shardCmd)).Should(Succeed())
 		Expect(o.Name).ShouldNot(BeEmpty())
 		Expect(o.Values).ShouldNot(BeNil())


### PR DESCRIPTION
fix #428

Change
- Support verifying componnetDef from shardingSpecs of Cluster.

Test
- After fixed, a redis cluster of mode "cluster" can be created correctly.

1. Edit go build configuration.
<img width="536" alt="image" src="https://github.com/user-attachments/assets/4b3dde2f-7da8-4cd8-a350-356fcf3bdd7a">

2. Run kbcli with create commands and get result.
<img width="233" alt="image" src="https://github.com/user-attachments/assets/91f2b7d4-4146-4e8e-8a8f-c922f5c19233">

3. Check the phase of redis cluster.
<img width="826" alt="image" src="https://github.com/user-attachments/assets/c48736ba-a958-42b2-9db7-bf6d1400b247">

