### PR TITLE
feat: imporve cluster register and addon

### DIFF
--- a/docs/user_docs/cli/kbcli_addon_install.md
+++ b/docs/user_docs/cli/kbcli_addon_install.md
@@ -22,6 +22,12 @@ kbcli addon install [flags]
   
   # install an addon with a specified version default index
   kbcli addon install apecloud-mysql --version 0.7.0
+  
+  # install an addon with a specified version and cluster chart of different version.
+  kbcli addon install apecloud-mysql --version 0.7.0 --cluster-chart-version 0.7.1
+  
+  # install an addon with a specified version and local path.
+  kbcli addon install apecloud-mysql --version 0.7.0 --path /path/to/local/chart
 ```
 
 ### Options

--- a/docs/user_docs/cli/kbcli_addon_install.md
+++ b/docs/user_docs/cli/kbcli_addon_install.md
@@ -37,7 +37,7 @@ kbcli addon install [flags]
       --cluster-chart-version string   specify the cluster chart version, use the same version as the addon by default
       --force                          force install the addon and ignore the version check
   -h, --help                           help for install
-      --index string                   specify the addon index index, use 'kubeblocks' by default (default "kubeblocks")
+      --index string                   specify the addon index, use 'kubeblocks' by default (default "kubeblocks")
       --path string                    specify the local path contains addon CRs and needs to be specified when operating offline
       --version string                 specify the addon version
 ```

--- a/docs/user_docs/cli/kbcli_addon_install.md
+++ b/docs/user_docs/cli/kbcli_addon_install.md
@@ -27,10 +27,13 @@ kbcli addon install [flags]
 ### Options
 
 ```
-      --force            force install the addon and ignore the version check
-  -h, --help             help for install
-      --index string     specify the addon index index, use 'kubeblocks' by default (default "kubeblocks")
-      --version string   specify the addon version
+      --cluster-chart-repo string      specify the repo of cluster chart, use the url of 'kubeblocks-addons' by default (default "https://jihulab.com/api/v4/projects/150246/packages/helm/stable")
+      --cluster-chart-version string   specify the cluster chart version, use the same version as the addon by default
+      --force                          force install the addon and ignore the version check
+  -h, --help                           help for install
+      --index string                   specify the addon index index, use 'kubeblocks' by default (default "kubeblocks")
+      --path string                    specify the local path contains addon CRs and needs to be specified when operating offline
+      --version string                 specify the addon version
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_addon_search.md
+++ b/docs/user_docs/cli/kbcli_addon_search.md
@@ -11,7 +11,8 @@ kbcli addon search [flags]
 ### Options
 
 ```
-  -h, --help   help for search
+  -h, --help          help for search
+      --path string   the local directory contains addon CRs
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_addon_search.md
+++ b/docs/user_docs/cli/kbcli_addon_search.md
@@ -8,6 +8,28 @@ Search the addon from index
 kbcli addon search [flags]
 ```
 
+### Examples
+
+```
+  # install an addon from default index
+  kbcli addon install apecloud-mysql
+  
+  # install an addon from default index and skip KubeBlocks version compatibility check
+  kbcli addon install apecloud-mysql --force
+  
+  # install an addon from a specified index
+  kbcli addon install apecloud-mysql --index my-index
+  
+  # install an addon with a specified version default index
+  kbcli addon install apecloud-mysql --version 0.7.0
+  
+  # install an addon with a specified version and cluster chart of different version.
+  kbcli addon install apecloud-mysql --version 0.7.0 --cluster-chart-version 0.7.1
+  
+  # install an addon with a specified version and local path.
+  kbcli addon install apecloud-mysql --version 0.7.0 --path /path/to/local/chart
+```
+
 ### Options
 
 ```

--- a/docs/user_docs/cli/kbcli_addon_upgrade.md
+++ b/docs/user_docs/cli/kbcli_addon_upgrade.md
@@ -23,6 +23,9 @@ kbcli addon upgrade [flags]
   # upgrade an addon with a specified version default index
   kbcli addon upgrade apecloud-mysql --version 0.7.0
   
+  # upgrade an addon with a specified version, default index and a different version of cluster chart
+  kbcli addon upgrade apecloud-mysql --version 0.7.0 --cluster-chart-version 0.7.1
+  
   # non-inplace upgrade an addon with a specified version
   kbcli addon upgrade apecloud-mysql  --inplace=false --version 0.7.0
   

--- a/docs/user_docs/cli/kbcli_addon_upgrade.md
+++ b/docs/user_docs/cli/kbcli_addon_upgrade.md
@@ -33,12 +33,15 @@ kbcli addon upgrade [flags]
 ### Options
 
 ```
-      --force            force upgrade the addon and ignore the version check
-  -h, --help             help for upgrade
-      --index string     specify the addon index index, use 'kubeblocks' by default (default "kubeblocks")
-      --inplace          when inplace is false, it will retain the existing addon and reinstall the new version of the addon, otherwise the upgrade will be in-place. The default is true. (default true)
-      --name string      name is the new version addon name need to set by user when inplace is false, it also will be used as resourceNamePrefix of an addon with multiple version.
-      --version string   specify the addon version
+      --cluster-chart-repo string      specify the repo of cluster chart, use the url of 'kubeblocks-addons' by default (default "https://jihulab.com/api/v4/projects/150246/packages/helm/stable")
+      --cluster-chart-version string   specify the cluster chart version, use the same version as the addon by default
+      --force                          force upgrade the addon and ignore the version check
+  -h, --help                           help for upgrade
+      --index string                   specify the addon index index, use 'kubeblocks' by default (default "kubeblocks")
+      --inplace                        when inplace is false, it will retain the existing addon and reinstall the new version of the addon, otherwise the upgrade will be in-place. The default is true. (default true)
+      --name string                    name is the new version addon name need to set by user when inplace is false, it also will be used as resourceNamePrefix of an addon with multiple version.
+      --path string                    specify the local path contains addon CRs and needs to be specified when operating offline
+      --version string                 specify the addon version
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_cluster_register.md
+++ b/docs/user_docs/cli/kbcli_cluster_register.md
@@ -5,7 +5,7 @@ title: kbcli cluster register
 Pull the cluster chart to the local cache and register the type to 'create' sub-command
 
 ```
-kbcli cluster register [NAME] --source [CHART-URL] [flags]
+kbcli cluster register [NAME] [flags]
 ```
 
 ### Examples
@@ -21,10 +21,13 @@ kbcli cluster register [NAME] --source [CHART-URL] [flags]
 ### Options
 
 ```
-      --alias string    Set the cluster type alias
-      --auto-approve    Skip interactive approval when registering an existed cluster type
-  -h, --help            help for register
-  -S, --source string   Specify the cluster type chart source, support a URL or a local file path
+      --alias string     Set the cluster type alias
+      --auto-approve     Skip interactive approval when registering an existed cluster type
+      --engine string    Specify the cluster chart name in helm repo
+  -h, --help             help for register
+      --repo string      Specify the url of helm repo which contains cluster charts (default "https://jihulab.com/api/v4/projects/150246/packages/helm/stable")
+  -S, --source string    Specify the cluster type chart source, support a URL or a local file path
+      --version string   Specify the version of cluster chart to register
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_cluster_register.md
+++ b/docs/user_docs/cli/kbcli_cluster_register.md
@@ -22,7 +22,6 @@ kbcli cluster register [NAME] [flags]
 
 ```
       --alias string     Set the cluster type alias
-      --auto-approve     Skip interactive approval when registering an existed cluster type
       --engine string    Specify the cluster chart name in helm repo
   -h, --help             help for register
       --repo string      Specify the url of helm repo which contains cluster charts (default "https://jihulab.com/api/v4/projects/150246/packages/helm/stable")

--- a/docs/user_docs/cli/kbcli_cluster_register.md
+++ b/docs/user_docs/cli/kbcli_cluster_register.md
@@ -15,7 +15,10 @@ kbcli cluster register [NAME] [flags]
   kbcli cluster register orioledb --source https://github.com/apecloud/helm-charts/releases/download/orioledb-cluster-0.6.0-beta.44/orioledb-cluster-0.6.0-beta.44.tgz
   
   # Register a cluster type from a local path file
-  kbcli cluster register neon -source pkg/cli/cluster/charts/neon-cluster.tgz
+  kbcli cluster register neon --source pkg/cli/cluster/charts/neon-cluster.tgz
+  
+  # Register a cluster type from a Helm repository, specifying the version and engine.
+  kbcli cluster register mysql --engine mysql --version 0.9.0 --repo https://jihulab.com/api/v4/projects/150246/packages/helm/stable
 ```
 
 ### Options

--- a/pkg/cluster/external_charts.go
+++ b/pkg/cluster/external_charts.go
@@ -38,15 +38,15 @@ import (
 	"github.com/apecloud/kbcli/pkg/util/flags"
 )
 
-// CliClusterTypesCacheDir is $HOME/.kbcli/cluster_types by default
-var CliClusterTypesCacheDir string
+// CliClusterChartConfig is $HOME/.kbcli/cluster_types by default
+var CliClusterChartConfig string
 
 // CliChartsCacheDir is $HOME/.kbcli/charts by default
 var CliChartsCacheDir string
 
 type clusterConfig []*TypeInstance
 
-// GlobalClusterChartConfig is kbcli global cluster chart config reference to CliClusterTypesCacheDir
+// GlobalClusterChartConfig is kbcli global cluster chart config reference to CliClusterChartConfig
 var GlobalClusterChartConfig clusterConfig
 var CacheFiles []fs.DirEntry
 
@@ -145,7 +145,7 @@ func GetChartCacheFiles() []fs.DirEntry {
 func ClearCharts(c ClusterType) {
 	// if the fail clusterType is from external config, remove the config and the related charts
 	if GlobalClusterChartConfig.RemoveConfig(c) {
-		if err := GlobalClusterChartConfig.WriteConfigs(CliClusterTypesCacheDir); err != nil {
+		if err := GlobalClusterChartConfig.WriteConfigs(CliClusterChartConfig); err != nil {
 			klog.V(2).Info(fmt.Sprintf("Warning: auto clear %s config fail due to: %s\n", c, err.Error()))
 
 		}
@@ -243,7 +243,7 @@ func (h *TypeInstance) PatchNewClusterType() error {
 	} else {
 		GlobalClusterChartConfig.AddConfig(h)
 	}
-	return GlobalClusterChartConfig.WriteConfigs(CliClusterTypesCacheDir)
+	return GlobalClusterChartConfig.WriteConfigs(CliClusterChartConfig)
 }
 
 var StandardSchema = map[string]interface{}{
@@ -307,15 +307,15 @@ var _ chartLoader = &TypeInstance{}
 
 func init() {
 	homeDir, _ := util.GetCliHomeDir()
-	CliClusterTypesCacheDir = filepath.Join(homeDir, types.CliClusterTypeConfigs)
+	CliClusterChartConfig = filepath.Join(homeDir, types.CliClusterTypeConfigs)
 	CliChartsCacheDir = filepath.Join(homeDir, types.CliChartsCache)
 
-	err := GlobalClusterChartConfig.ReadConfigs(CliClusterTypesCacheDir)
+	err := GlobalClusterChartConfig.ReadConfigs(CliClusterChartConfig)
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 	// check charts cache dir
 	CacheFiles = GetChartCacheFiles()
-	RegisterCMD(GlobalClusterChartConfig, CliClusterTypesCacheDir)
+	RegisterCMD(GlobalClusterChartConfig, CliClusterChartConfig)
 }

--- a/pkg/cluster/external_charts.go
+++ b/pkg/cluster/external_charts.go
@@ -269,12 +269,12 @@ func (h *TypeInstance) ValidateChartSchema() (bool, error) {
 
 	data := c.Schema
 	if len(data) == 0 {
-		return false, fmt.Errorf("schema of the chart doesn't exist")
+		return false, fmt.Errorf("register cluster chart of %s failed, schema of the chart doesn't exist", h.Name)
 	}
 
 	var schema map[string]interface{}
 	if err := json.Unmarshal(data, &schema); err != nil {
-		return false, fmt.Errorf("error decoding JSON: %s", err)
+		return false, fmt.Errorf("register cluster chart of %s failed, error decoding JSON: %s", h.Name, err)
 	}
 
 	if err := validateSchema(schema, StandardSchema); err != nil {
@@ -289,14 +289,14 @@ func validateSchema(schema, standard map[string]interface{}) error {
 		if subStandard, ok := val.(map[string]interface{}); ok {
 			subSchema, ok := schema[key].(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("schema missing required map key '%s'", key)
+				return fmt.Errorf("register cluster chart failed, schema missing required map key '%s'", key)
 			}
 			if err := validateSchema(subSchema, subStandard); err != nil {
 				return err
 			}
 		} else {
 			if _, exists := schema[key]; !exists {
-				return fmt.Errorf("schema missing required key '%s'", key)
+				return fmt.Errorf("register cluster chart failed, schema missing required key '%s'", key)
 			}
 		}
 	}

--- a/pkg/cluster/external_charts.go
+++ b/pkg/cluster/external_charts.go
@@ -224,8 +224,25 @@ func (h *TypeInstance) register(subcmd ClusterType) error {
 			return nil
 		}
 	}
-	//TODO: replace with 'kbcli cluster register --engine= --repo= --version='
-	return fmt.Errorf("can't find the %s in cache, please use 'kbcli cluster pull %s --url %s' first", h.Name.String(), h.Name.String(), h.URL)
+	return fmt.Errorf("can't find the %s in cache, please use 'kbcli cluster register %s --url %s' first", h.Name.String(), h.Name.String(), h.URL)
+}
+
+func (h *TypeInstance) PatchNewClusterType() error {
+	if err := h.PreCheck(); err != nil {
+		return fmt.Errorf("the chart of %s pre-check unsuccssful: %s", h.Name, err.Error())
+	}
+	isChartExist := false
+	for _, item := range GlobalClusterChartConfig {
+		if h.Name == item.Name {
+			isChartExist = true
+		}
+	}
+	if isChartExist {
+		GlobalClusterChartConfig.UpdateConfig(h)
+	} else {
+		GlobalClusterChartConfig.AddConfig(h)
+	}
+	return GlobalClusterChartConfig.WriteConfigs(CliClusterTypesCacheDir)
 }
 
 var _ chartLoader = &TypeInstance{}

--- a/pkg/cluster/register_test.go
+++ b/pkg/cluster/register_test.go
@@ -46,7 +46,7 @@ var _ = Describe("cluster register", func() {
 		Expect(err).Should(Succeed())
 	})
 
-	It("test external chart", func() {
+	It("test fake chart", func() {
 		fakeChart := &TypeInstance{
 			Name:      "fake",
 			URL:       "www.fake-chart-hub/fake.tgz",
@@ -58,6 +58,9 @@ var _ = Describe("cluster register", func() {
 		_, err := fakeChart.loadChart()
 		Expect(err).Should(HaveOccurred())
 		Expect(fakeChart.register("fake")).Should(HaveOccurred())
+		Expect(fakeChart.PatchNewClusterType()).Should(HaveOccurred())
+		_, err = fakeChart.ValidateChartSchema()
+		Expect(err).Should(HaveOccurred())
 	})
 
 	Context("test Config reader", func() {

--- a/pkg/cmd/addon/addon.go
+++ b/pkg/cmd/addon/addon.go
@@ -49,6 +49,8 @@ import (
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 
 	"github.com/apecloud/kbcli/pkg/action"
+	"github.com/apecloud/kbcli/pkg/cluster"
+	clusterCmd "github.com/apecloud/kbcli/pkg/cmd/cluster"
 	"github.com/apecloud/kbcli/pkg/cmd/plugin"
 	"github.com/apecloud/kbcli/pkg/printer"
 	"github.com/apecloud/kbcli/pkg/types"
@@ -224,6 +226,7 @@ func newEnableCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 				util.CheckErr(o.complete(o, cmd, []string{name}))
 				util.CheckErr(o.CmdComplete(cmd))
 				util.CheckErr(o.Run())
+				util.CheckErr(o.registerClusterChart(f, streams, name))
 			}
 		},
 	}
@@ -319,6 +322,14 @@ func (o *addonCmdOpts) init(args []string) error {
 		viper.SetDefault(constant.CfgKeyServerInfo, *ver)
 	}
 
+	return nil
+}
+
+func (o *addonCmdOpts) registerClusterChart(f cmdutil.Factory, streams genericiooptions.IOStreams, engine string) error {
+	if err := clusterCmd.RegisterClusterChart(f, streams, "", engine, o.addon.Spec.Version, types.ClusterChartsRepoURL); err != nil {
+		cluster.ClearCharts(cluster.ClusterType(engine))
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cmd/addon/addon.go
+++ b/pkg/cmd/addon/addon.go
@@ -49,7 +49,6 @@ import (
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 
 	"github.com/apecloud/kbcli/pkg/action"
-	"github.com/apecloud/kbcli/pkg/cluster"
 	clusterCmd "github.com/apecloud/kbcli/pkg/cmd/cluster"
 	"github.com/apecloud/kbcli/pkg/cmd/plugin"
 	"github.com/apecloud/kbcli/pkg/printer"
@@ -226,7 +225,7 @@ func newEnableCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 				util.CheckErr(o.complete(o, cmd, []string{name}))
 				util.CheckErr(o.CmdComplete(cmd))
 				util.CheckErr(o.Run())
-				util.CheckErr(o.registerClusterChart(f, streams, name))
+				util.CheckErr(clusterCmd.RegisterClusterChart(f, streams, "", name, o.addon.Spec.Version, types.ClusterChartsRepoURL))
 			}
 		},
 	}
@@ -322,14 +321,6 @@ func (o *addonCmdOpts) init(args []string) error {
 		viper.SetDefault(constant.CfgKeyServerInfo, *ver)
 	}
 
-	return nil
-}
-
-func (o *addonCmdOpts) registerClusterChart(f cmdutil.Factory, streams genericiooptions.IOStreams, engine string) error {
-	if err := clusterCmd.RegisterClusterChart(f, streams, "", engine, o.addon.Spec.Version, types.ClusterChartsRepoURL); err != nil {
-		cluster.ClearCharts(cluster.ClusterType(engine))
-		return err
-	}
 	return nil
 }
 

--- a/pkg/cmd/addon/addon.go
+++ b/pkg/cmd/addon/addon.go
@@ -111,7 +111,7 @@ func NewAddonCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.C
 		newEnableCmd(f, streams),
 		newDisableCmd(f, streams),
 		newIndexCmd(streams),
-		newSearchCmd(streams),
+		newSearchCmd(f, streams),
 		newInstallCmd(f, streams),
 		newUninstallCmd(f, streams),
 		newUpgradeCmd(f, streams),

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -187,7 +187,7 @@ func (o *installOption) Complete() error {
 
 	// descending order of versions
 	for _, item := range addons {
-		if item.index.name == o.index {
+		if o.path != "" || item.index.name == o.index {
 			// if the version not specified, use the latest version
 			if o.version == "" {
 				o.addon = item.addon

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -246,7 +246,7 @@ It will automatically skip version checks, which may result in the cluster not r
 	return err
 }
 
-// Run will apply the addon.yaml to K8s
+// Run will apply the addon.yaml to K8s and register the cluster chart with version and repo specified
 func (o *installOption) Run() error {
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o.addon)
 	if err != nil {

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -169,12 +169,13 @@ func (o *installOption) Complete() error {
 		if err != nil {
 			return err
 		}
-		addons, err = searchAddon(o.name, dir, "")
+		if addons, err = searchAddon(o.name, dir, ""); err != nil {
+			return err
+		}
 	} else {
-		addons, err = searchAddon(o.name, filepath.Dir(o.path), filepath.Base(o.path))
-	}
-	if err != nil {
-		return err
+		if addons, err = searchAddon(o.name, filepath.Dir(o.path), filepath.Base(o.path)); err != nil {
+			return err
+		}
 	}
 
 	sort.Slice(addons, func(i, j int) bool {

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -59,6 +59,12 @@ var addonInstallExample = templates.Examples(`
 
 	# install an addon with a specified version default index
 	kbcli addon install apecloud-mysql --version 0.7.0
+
+	# install an addon with a specified version and cluster chart of different version.
+	kbcli addon install apecloud-mysql --version 0.7.0 --cluster-chart-version 0.7.1
+
+	# install an addon with a specified version and local path.
+	kbcli addon install apecloud-mysql --version 0.7.0 --path /path/to/local/chart
 `)
 
 type baseOption struct {
@@ -161,7 +167,8 @@ func (o *installOption) Complete() error {
 		return fmt.Errorf("the version %s does not comply with the standards", o.version)
 	}
 
-	// find addons in the default index dir or the specified path.
+	// If no local path is specified, we search all indexes in the default index directory.
+	// When a local path is specified, we assume the last part of the path is the index and search only that.
 	if o.path == "" {
 		dir, err := util.GetCliAddonDir()
 		if err != nil {

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -148,7 +148,7 @@ func newInstallCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 	}
 	cmd.Flags().BoolVar(&o.force, "force", false, "force install the addon and ignore the version check")
 	cmd.Flags().StringVar(&o.version, "version", "", "specify the addon version")
-	cmd.Flags().StringVar(&o.index, "index", types.DefaultIndexName, "specify the addon index index, use 'kubeblocks' by default")
+	cmd.Flags().StringVar(&o.index, "index", types.DefaultIndexName, "specify the addon index, use 'kubeblocks' by default")
 	cmd.Flags().StringVar(&o.clusterChartVersion, "cluster-chart-version", "", "specify the cluster chart version, use the same version as the addon by default")
 	cmd.Flags().StringVar(&o.clusterChartRepo, "cluster-chart-repo", types.ClusterChartsRepoURL, "specify the repo of cluster chart, use the url of 'kubeblocks-addons' by default")
 	cmd.Flags().StringVar(&o.path, "path", "", "specify the local path contains addon CRs and needs to be specified when operating offline")
@@ -256,7 +256,7 @@ It will automatically skip version checks, which may result in the cluster not r
 	return err
 }
 
-// Run will apply the addon.yaml to K8s and register the cluster chart
+// Run will apply the addon.yaml to K8s
 func (o *installOption) Run(f cmdutil.Factory, streams genericiooptions.IOStreams) error {
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o.addon)
 	if err != nil {

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -40,7 +40,6 @@ import (
 
 	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
 
-	"github.com/apecloud/kbcli/pkg/cluster"
 	clusterCmd "github.com/apecloud/kbcli/pkg/cmd/cluster"
 	"github.com/apecloud/kbcli/pkg/printer"
 	"github.com/apecloud/kbcli/pkg/types"
@@ -139,9 +138,7 @@ func newInstallCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 			util.CheckErr(o.Run(f, streams))
 			// avoid unnecessary messages for upgrade
 			fmt.Fprintf(o.Out, "addon %s installed successfully\n", o.name)
-			if err := clusterCmd.RegisterClusterChart(f, streams, "", o.name, o.clusterChartVersion, o.clusterChartRepo); err == nil {
-				fmt.Fprintf(o.Out, clusterCmd.BuildRegisterSuccessExamples(cluster.ClusterType(o.name)))
-			} else {
+			if err := clusterCmd.RegisterClusterChart(f, streams, "", o.name, o.clusterChartVersion, o.clusterChartRepo); err != nil {
 				util.CheckErr(err)
 			}
 		},

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -191,6 +191,7 @@ func (o *installOption) Complete() error {
 			// if the version not specified, use the latest version
 			if o.version == "" {
 				o.addon = item.addon
+				o.version = getAddonVersion(item.addon)
 				break
 			} else if o.version == getAddonVersion(item.addon) {
 				o.addon = item.addon
@@ -244,13 +245,14 @@ It will automatically skip version checks, which may result in the cluster not r
 	return err
 }
 
-// Run will apply the addon.yaml to K8s and register the cluster chart with version and repo specified
+// Run will apply the addon.yaml to K8s and register the cluster chart
 func (o *installOption) Run(f cmdutil.Factory, streams genericiooptions.IOStreams) error {
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o.addon)
 	if err != nil {
 		return err
 	}
 	if err = clusterCmd.RegisterClusterChart(f, streams, "", o.name, o.clusterChartVersion, o.clusterChartRepo); err != nil {
+		cluster.ClearCharts(cluster.ClusterType(o.name))
 		return err
 	}
 	_, err = o.Dynamic.Resource(o.GVR).Create(context.Background(), &unstructured.Unstructured{Object: item}, metav1.CreateOptions{})

--- a/pkg/cmd/addon/install_test.go
+++ b/pkg/cmd/addon/install_test.go
@@ -22,7 +22,6 @@ package addon
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	clientfake "k8s.io/client-go/rest/fake"
@@ -34,10 +33,13 @@ import (
 	"github.com/apecloud/kbcli/pkg/types"
 )
 
-var _ = Describe("index test", func() {
-	var streams genericiooptions.IOStreams
-	var tf *cmdtesting.TestFactory
-	var addonName = "apecloud-mysql"
+var _ = Describe("install test", func() {
+	var (
+		streams   genericiooptions.IOStreams
+		tf        *cmdtesting.TestFactory
+		addonName = "apecloud-mysql"
+	)
+
 	BeforeEach(func() {
 		streams, _, _, _ = genericiooptions.NewTestIOStreams()
 		tf = cmdtesting.NewTestFactory().WithNamespace(testNamespace)
@@ -141,4 +143,28 @@ var _ = Describe("index test", func() {
 		option.force = true
 		Expect(option.Validate()).Should(Succeed())
 	})
+
+	It("test install with path specified", func() {
+		var (
+			testAddonName = "apecloud-mysql"
+			testVersion   = "0.7.0"
+			testLocalPath = "./testdata/kubeblocks"
+		)
+
+		o := &installOption{
+			baseOption: baseOption{
+				Factory:   tf,
+				IOStreams: streams,
+				GVR:       types.AddonGVR(),
+			},
+			name:    testAddonName,
+			version: testVersion,
+			path:    testLocalPath,
+		}
+
+		Expect(o.Complete()).Should(Succeed())
+		Expect(o.addon).ShouldNot(BeNil())
+		Expect(o.addon.Labels["app.kubernetes.io/version"]).Should(Equal(testVersion))
+	})
+
 })

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -33,61 +33,98 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/klog/v2"
 
-	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
-
+	"github.com/apecloud/kbcli/pkg/action"
 	"github.com/apecloud/kbcli/pkg/printer"
+	"github.com/apecloud/kbcli/pkg/types"
 	"github.com/apecloud/kbcli/pkg/util"
+	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 type searchResult struct {
-	index index
-	addon *extensionsv1alpha1.Addon
+	index       index
+	addon       *extensionsv1alpha1.Addon
+	isInstalled bool
 }
 
-func newSearchCmd(streams genericiooptions.IOStreams) *cobra.Command {
+type searchOpts struct {
+	// the name of addon to search, if not specified returns all the addons in the indexes
+	name string
+	// the local path contains addon CRs and needs to be specified when operating offline
+	path string
+}
+
+func newSearchCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := &searchOpts{}
 	cmd := &cobra.Command{
 		Use:   "search",
 		Short: "Search the addon from index",
-		Args:  cobra.ExactArgs(1),
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			util.CheckErr(util.EnableLogToFile(cmd.Flags()))
 			util.CheckErr(addDefaultIndex())
 		},
 		Run: func(_ *cobra.Command, args []string) {
-			util.CheckErr(search(args, streams.Out))
+			if len(args) == 0 {
+				o.name = ""
+			} else {
+				o.name = args[0]
+			}
+			util.CheckErr(o.search(streams.Out, &addonListOpts{
+				ListOptions: action.NewListOptions(f, streams, types.AddonGVR()),
+			}))
 		},
 	}
+	cmd.Flags().StringVar(&o.path, "path", "", "the local directory contains addon CRs")
 	return cmd
 }
 
-func search(args []string, out io.Writer) error {
+func (o *searchOpts) search(out io.Writer, addonListOpts *addonListOpts) error {
+	var (
+		err     error
+		results []searchResult
+	)
+	if o.path == "" {
+		dir, err := util.GetCliAddonDir()
+		if err != nil {
+			return err
+		}
+		results, err = searchAddon(o.name, dir, "")
+	} else {
+		results, err = searchAddon(o.name, filepath.Dir(o.path), filepath.Base(o.path))
+	}
+	if err != nil {
+		return err
+	}
+
 	tbl := printer.NewTablePrinter(out)
-	tbl.AddRow("ADDON", "VERSION", "INDEX")
-	dir, err := util.GetCliAddonDir()
-	if err != nil {
-		return err
-	}
-	results, err := searchAddon(args[0], dir)
-	if err != nil {
-		return err
-	}
-	if len(results) == 0 {
-		fmt.Fprintf(out, "%s addon not found. Please update your index or check the addon name\n", args[0])
-		return nil
-	}
-	for _, res := range results {
-		tbl.AddRow(res.addon.Name, getAddonVersion(res.addon), res.index.name)
+
+	if o.name == "" {
+		tbl.AddRow("ADDON", "STATUS")
+		statusMap := map[bool]string{
+			true:  "installed",
+			false: "uninstalled",
+		}
+		results = uniqueByName(results)
+		checkAddonInstalled(&results, addonListOpts)
+		for _, res := range results {
+			tbl.AddRow(res.addon.Name, statusMap[res.isInstalled])
+		}
+	} else {
+		tbl.AddRow("ADDON", "VERSION", "INDEX")
+		if len(results) == 0 {
+			fmt.Fprintf(out, "%s addon not found. Please update your index or check the addon name\n", o.name)
+			return nil
+		}
+		for _, res := range results {
+			tbl.AddRow(res.addon.Name, getAddonVersion(res.addon), res.index.name)
+		}
 	}
 	tbl.Print()
 	return nil
 }
 
 // searchAddon function will search for the addons with the specified name in the index of the specified directory and return them.
-func searchAddon(name string, indexDir string) ([]searchResult, error) {
-	indexes, err := getAllIndexes(indexDir)
-	if err != nil {
-		return nil, err
-	}
+func searchAddon(name string, indexDir string, theIndex string) ([]searchResult, error) {
 	var res []searchResult
 	searchInDir := func(i index) error {
 		return filepath.WalkDir(filepath.Join(indexDir, i.name), func(path string, d fs.DirEntry, err error) error {
@@ -113,11 +150,25 @@ func searchAddon(name string, indexDir string) ([]searchResult, error) {
 				if addon.Kind != "Addon" {
 					return filepath.SkipDir
 				}
-				if addon.Name == name {
-					res = append(res, searchResult{i, addon})
+				if name == "" || addon.Name == name {
+					res = append(res, searchResult{i, addon, false})
 				}
 			}
 			return nil
+		})
+	}
+
+	var indexes []index
+	var err error
+	if theIndex == "" {
+		indexes, err = getAllIndexes(indexDir)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		indexes = append(indexes, index{
+			name: theIndex,
+			url:  "",
 		})
 	}
 

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -129,7 +129,9 @@ func (o *searchOpts) search(out io.Writer, addonListOpts *addonListOpts) error {
 	} else {
 		tbl.AddRow("ADDON", "VERSION", "INDEX")
 		if len(results) == 0 {
-			fmt.Fprintf(out, "%s addon not found. Please update your index or check the addon name\n", o.name)
+			fmt.Fprintf(out, "%s addon not found. Please update your index or check the addon name.\n"+
+				"You can use the command 'kbcli addon index update --all=true' to update all indexes,\n"+
+				"or specify a local path containing addons with the command 'kbcli addon search --path=/path/to/local/chart'", o.name)
 			return nil
 		}
 		for _, res := range results {

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -88,12 +88,13 @@ func (o *searchOpts) search(out io.Writer, addonListOpts *addonListOpts) error {
 		if err != nil {
 			return err
 		}
-		results, err = searchAddon(o.name, dir, "")
+		if results, err = searchAddon(o.name, dir, ""); err != nil {
+			return err
+		}
 	} else {
-		results, err = searchAddon(o.name, filepath.Dir(o.path), filepath.Base(o.path))
-	}
-	if err != nil {
-		return err
+		if results, err = searchAddon(o.name, filepath.Dir(o.path), filepath.Base(o.path)); err != nil {
+			return err
+		}
 	}
 
 	tbl := printer.NewTablePrinter(out)

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"k8s.io/kubectl/pkg/util/templates"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -41,6 +42,17 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
+var addonSearchExample = templates.Examples(`
+	# search the addons of all index
+	kbcli addon search
+
+	# search the addons from a specified local path 
+	kbcli addon search --path /path/to/local/chart
+
+	# search different versions and indexes of an addon
+	kbcli addon search apecloud-mysql
+`)
+
 type searchResult struct {
 	index       index
 	addon       *extensionsv1alpha1.Addon
@@ -57,8 +69,9 @@ type searchOpts struct {
 func newSearchCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := &searchOpts{}
 	cmd := &cobra.Command{
-		Use:   "search",
-		Short: "Search the addon from index",
+		Use:     "search",
+		Short:   "Search the addon from index",
+		Example: addonInstallExample,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			util.CheckErr(util.EnableLogToFile(cmd.Flags()))
 			util.CheckErr(addDefaultIndex())

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -98,7 +98,6 @@ func (o *searchOpts) search(out io.Writer, addonListOpts *addonListOpts) error {
 	}
 
 	tbl := printer.NewTablePrinter(out)
-
 	if o.name == "" {
 		tbl.AddRow("ADDON", "STATUS")
 		statusMap := map[bool]string{
@@ -162,11 +161,13 @@ func searchAddon(name string, indexDir string, theIndex string) ([]searchResult,
 	var indexes []index
 	var err error
 	if theIndex == "" {
+		// search all the indexes from the dir
 		indexes, err = getAllIndexes(indexDir)
 		if err != nil {
 			return nil, err
 		}
 	} else {
+		// add the specified index
 		indexes = append(indexes, index{
 			name: theIndex,
 			url:  "",

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -105,7 +105,10 @@ func (o *searchOpts) search(out io.Writer, addonListOpts *addonListOpts) error {
 			false: "uninstalled",
 		}
 		results = uniqueByName(results)
-		checkAddonInstalled(&results, addonListOpts)
+		err := checkAddonInstalled(&results, addonListOpts)
+		if err != nil {
+			return err
+		}
 		for _, res := range results {
 			tbl.AddRow(res.addon.Name, statusMap[res.isInstalled])
 		}

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"k8s.io/kubectl/pkg/util/templates"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -33,13 +32,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
 
 	"github.com/apecloud/kbcli/pkg/action"
 	"github.com/apecloud/kbcli/pkg/printer"
 	"github.com/apecloud/kbcli/pkg/types"
 	"github.com/apecloud/kbcli/pkg/util"
-	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 var addonSearchExample = templates.Examples(`

--- a/pkg/cmd/addon/search_test.go
+++ b/pkg/cmd/addon/search_test.go
@@ -24,12 +24,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 var _ = Describe("search test", func() {
 	var streams genericiooptions.IOStreams
+	var f cmdutil.Factory
 	var out *bytes.Buffer
 	const (
 		testAddonName       = "apecloud-mysql"
@@ -40,11 +42,11 @@ var _ = Describe("search test", func() {
 		streams, _, out, _ = genericiooptions.NewTestIOStreams()
 	})
 	It("test search cmd", func() {
-		Expect(newSearchCmd(streams)).ShouldNot(BeNil())
+		Expect(newSearchCmd(f, streams)).ShouldNot(BeNil())
 	})
 
 	It("test search", func() {
-		cmd := newSearchCmd(streams)
+		cmd := newSearchCmd(f, streams)
 		cmd.Run(cmd, []string{testAddonNotExisted})
 		Expect(out.String()).Should(Equal("fake-addon addon not found. Please update your index or check the addon name\n"))
 	})
@@ -66,7 +68,7 @@ var _ = Describe("search test", func() {
 				"kubeblocks", "Addon", "apecloud-mysql", "0.8.0-alpha.6",
 			},
 		}
-		result, err := searchAddon(testAddonName, testIndexDir)
+		result, err := searchAddon(testAddonName, testIndexDir, "")
 		Expect(err).Should(Succeed())
 		Expect(result).Should(HaveLen(3))
 		for i := range result {

--- a/pkg/cmd/addon/search_test.go
+++ b/pkg/cmd/addon/search_test.go
@@ -64,7 +64,7 @@ var _ = Describe("search test", func() {
 	It("test search cmd Run with addon specified", func() {
 		cmd := newSearchCmd(tf, streams)
 		cmd.Run(cmd, []string{testAddonNotExisted})
-		Expect(out.String()).Should(Equal("fake-addon addon not found. Please update your index or check the addon name\n"))
+		Expect(out.String()).Should(ContainSubstring("Please update your index"))
 	})
 
 	It("test addon search", func() {

--- a/pkg/cmd/addon/search_test.go
+++ b/pkg/cmd/addon/search_test.go
@@ -21,6 +21,7 @@ package addon
 
 import (
 	"bytes"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,6 +38,7 @@ var _ = Describe("search test", func() {
 		testAddonName       = "apecloud-mysql"
 		testAddonNotExisted = "fake-addon"
 		testIndexDir        = "./testdata"
+		testLocalPath       = "./testdata/kubeblocks"
 	)
 	BeforeEach(func() {
 		streams, _, out, _ = genericiooptions.NewTestIOStreams()
@@ -69,6 +71,34 @@ var _ = Describe("search test", func() {
 			},
 		}
 		result, err := searchAddon(testAddonName, testIndexDir, "")
+		Expect(err).Should(Succeed())
+		Expect(result).Should(HaveLen(3))
+		for i := range result {
+			Expect(result[i].index.name).Should(Equal(expect[i].index))
+			Expect(result[i].addon.Name).Should(Equal(expect[i].addonName))
+			Expect(result[i].addon.Kind).Should(Equal(expect[i].kind))
+			Expect(getAddonVersion(result[i].addon)).Should(Equal(expect[i].version))
+		}
+	})
+
+	It("test addon search specify local path", func() {
+		expect := []struct {
+			index     string
+			kind      string
+			addonName string
+			version   string
+		}{
+			{
+				"kubeblocks", "Addon", "apecloud-mysql", "0.7.0",
+			},
+			{
+				"kubeblocks", "Addon", "apecloud-mysql", "0.8.0-alpha.5",
+			},
+			{
+				"kubeblocks", "Addon", "apecloud-mysql", "0.8.0-alpha.6",
+			},
+		}
+		result, err := searchAddon(testAddonName, filepath.Dir(testLocalPath), filepath.Base(testLocalPath))
 		Expect(err).Should(Succeed())
 		Expect(result).Should(HaveLen(3))
 		for i := range result {

--- a/pkg/cmd/addon/uninstall.go
+++ b/pkg/cmd/addon/uninstall.go
@@ -29,6 +29,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
+	"github.com/apecloud/kbcli/pkg/cluster"
 	"github.com/apecloud/kbcli/pkg/types"
 	"github.com/apecloud/kbcli/pkg/util"
 )
@@ -83,6 +84,7 @@ func (o *uninstallOption) Run() error {
 			return err
 		}
 		fmt.Fprintf(o.Out, "addon %s uninstalled successfully\n", name)
+		cluster.GlobalClusterChartConfig.RemoveConfig(cluster.ClusterType(name))
 	}
 	return nil
 }

--- a/pkg/cmd/addon/uninstall.go
+++ b/pkg/cmd/addon/uninstall.go
@@ -84,7 +84,8 @@ func (o *uninstallOption) Run() error {
 			return err
 		}
 		fmt.Fprintf(o.Out, "addon %s uninstalled successfully\n", name)
-		cluster.GlobalClusterChartConfig.RemoveConfig(cluster.ClusterType(name))
+		cluster.ClearCharts(cluster.ClusterType(name))
+		fmt.Fprintf(o.Out, "cluster chart removed successfully\n")
 	}
 	return nil
 }

--- a/pkg/cmd/addon/upgrade.go
+++ b/pkg/cmd/addon/upgrade.go
@@ -53,6 +53,9 @@ var addonUpgradeExample = templates.Examples(`
 	# upgrade an addon with a specified version default index 
 	kbcli addon upgrade apecloud-mysql --version 0.7.0
 
+	# upgrade an addon with a specified version, default index and a different version of cluster chart
+	kbcli addon upgrade apecloud-mysql --version 0.7.0 --cluster-chart-version 0.7.1
+
 	# non-inplace upgrade an addon with a specified version
 	kbcli addon upgrade apecloud-mysql  --inplace=false --version 0.7.0
 

--- a/pkg/cmd/addon/upgrade.go
+++ b/pkg/cmd/addon/upgrade.go
@@ -103,6 +103,9 @@ func newUpgradeCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 	cmd.Flags().StringVar(&o.index, "index", types.DefaultIndexName, "specify the addon index index, use 'kubeblocks' by default")
 	cmd.Flags().BoolVar(&o.inplace, "inplace", true, "when inplace is false, it will retain the existing addon and reinstall the new version of the addon, otherwise the upgrade will be in-place. The default is true.")
 	cmd.Flags().StringVar(&o.rename, "name", "", "name is the new version addon name need to set by user when inplace is false, it also will be used as resourceNamePrefix of an addon with multiple version.")
+	cmd.Flags().StringVar(&o.clusterChartVersion, "cluster-chart-version", "", "specify the cluster chart version, use the same version as the addon by default")
+	cmd.Flags().StringVar(&o.clusterChartRepo, "cluster-chart-repo", types.ClusterChartsRepoURL, "specify the repo of cluster chart, use the url of 'kubeblocks-addons' by default")
+	cmd.Flags().StringVar(&o.path, "path", "", "specify the local path contains addon CRs and needs to be specified when operating offline")
 	return cmd
 }
 

--- a/pkg/cmd/addon/upgrade.go
+++ b/pkg/cmd/addon/upgrade.go
@@ -95,7 +95,7 @@ func newUpgradeCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 			o.name = args[0]
 			util.CheckErr(o.Complete())
 			util.CheckErr(o.Validate())
-			util.CheckErr(o.Run())
+			util.CheckErr(o.Run(f, streams))
 		},
 	}
 	cmd.Flags().BoolVar(&o.force, "force", false, "force upgrade the addon and ignore the version check")
@@ -142,14 +142,14 @@ func (o *upgradeOption) Validate() error {
 	return o.installOption.Validate()
 }
 
-func (o *upgradeOption) Run() error {
+func (o *upgradeOption) Run(f cmdutil.Factory, streams genericiooptions.IOStreams) error {
 	if !o.inplace {
 		if o.addon.Spec.Helm.InstallValues.SetValues != nil {
 			o.addon.Spec.Helm.InstallValues.SetValues = append(o.addon.Spec.Helm.InstallValues.SetValues, fmt.Sprintf("%s=%s", types.AddonResourceNamePrefix, o.rename))
 		}
 		o.addon.Spec.Helm.InstallValues.SetValues = []string{fmt.Sprintf("%s=%s", types.AddonResourceNamePrefix, o.rename)}
 		o.addon.Name = o.rename
-		err := o.installOption.Run()
+		err := o.installOption.Run(f, streams)
 		if err == nil {
 			fmt.Printf("Addon %s-%s upgrade successed.\n", o.rename, o.version)
 		}

--- a/pkg/cmd/addon/util.go
+++ b/pkg/cmd/addon/util.go
@@ -70,9 +70,8 @@ func uniqueByName(objects []searchResult) []searchResult {
 }
 
 func checkAddonInstalled(objects *[]searchResult, o *addonListOpts) {
+	// list installed addons
 	var installedAddons []string
-
-	// get addon-list result
 	o.Print = false
 	o.Names = nil
 	r, _ := o.Run()
@@ -87,7 +86,7 @@ func checkAddonInstalled(objects *[]searchResult, o *addonListOpts) {
 		installedAddons = append(installedAddons, listItem.Name)
 	}
 
-	// mark installed on addons from addon-list result
+	// mark installed on addons from the list result
 	sort.Strings(installedAddons)
 	sort.Slice(*objects, func(i, j int) bool {
 		return (*objects)[i].addon.Name < (*objects)[j].addon.Name
@@ -111,7 +110,7 @@ func checkAddonInstalled(objects *[]searchResult, o *addonListOpts) {
 		}
 	}
 
-	// sort by 'uninstalled < installed'
+	// sort by the priority of 'uninstalled < installed'
 	sort.Slice(*objects, func(i, j int) bool {
 		return (*objects)[j].isInstalled
 	})

--- a/pkg/cmd/addon/util.go
+++ b/pkg/cmd/addon/util.go
@@ -93,14 +93,21 @@ func checkAddonInstalled(objects *[]searchResult, o *addonListOpts) {
 		return (*objects)[i].addon.Name < (*objects)[j].addon.Name
 	})
 	for i, j := 0, 0; i < len(installedAddons) && j < len(*objects); {
-		if installedAddons[i] == (*objects)[j].addon.Name {
-			(*objects)[j].isInstalled = true
-			i++
-			j++
-		} else if installedAddons[i] < (*objects)[j].addon.Name {
-			i++
-		} else if installedAddons[i] > (*objects)[j].addon.Name {
-			j++
+		switch {
+		case installedAddons[i] == (*objects)[j].addon.Name:
+			{
+				(*objects)[j].isInstalled = true
+				i++
+				j++
+			}
+		case installedAddons[i] < (*objects)[j].addon.Name:
+			{
+				i++
+			}
+		case installedAddons[i] > (*objects)[j].addon.Name:
+			{
+				j++
+			}
 		}
 	}
 

--- a/pkg/cmd/cluster/register.go
+++ b/pkg/cmd/cluster/register.go
@@ -112,6 +112,7 @@ func RegisterClusterChart(f cmdutil.Factory, streams genericiooptions.IOStreams,
 		return err
 	}
 	if err := o.run(); err != nil {
+		cluster.ClearCharts(cluster.ClusterType(engine))
 		return err
 	}
 	if _, err := fmt.Fprint(streams.Out, BuildRegisterSuccessExamples(o.clusterType)); err != nil {

--- a/pkg/cmd/cluster/register.go
+++ b/pkg/cmd/cluster/register.go
@@ -94,7 +94,7 @@ func newRegisterCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobr
 	return cmd
 }
 
-// RegisterClusterChart a util function to register cluster chart.
+// RegisterClusterChart a util function to register cluster chart used by addon install, upgrade and enable.
 func RegisterClusterChart(f cmdutil.Factory, streams genericiooptions.IOStreams, source, engine, version, repo string) error {
 	o := &registerOption{
 		Factory:     f,
@@ -119,7 +119,7 @@ func RegisterClusterChart(f cmdutil.Factory, streams genericiooptions.IOStreams,
 
 // validate will check the flags of command
 func (o *registerOption) validate() error {
-	re := regexp.MustCompile(`^[a-zA-Z0-9]{1,16}$`)
+	re := regexp.MustCompile(`^[a-zA-Z0-9-]{1,16}$`)
 	if !re.MatchString(o.clusterType.String()) {
 		return fmt.Errorf("cluster type %s is not appropriate as a subcommand", o.clusterType.String())
 	}

--- a/pkg/cmd/cluster/register.go
+++ b/pkg/cmd/cluster/register.go
@@ -21,6 +21,7 @@ package cluster
 
 import (
 	"fmt"
+	"github.com/apecloud/kbcli/pkg/util/prompt"
 	"io"
 	"net/url"
 	"os"
@@ -31,14 +32,15 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/apecloud/kbcli/pkg/cluster"
+	"github.com/apecloud/kbcli/pkg/types"
 	"github.com/apecloud/kbcli/pkg/util"
 	"github.com/apecloud/kbcli/pkg/util/helm"
-	"github.com/apecloud/kbcli/pkg/util/prompt"
 )
 
 var clusterRegisterExample = templates.Examples(`
@@ -58,6 +60,9 @@ type registerOption struct {
 	alias       string
 	// cachedName is the filename cached locally
 	cachedName string
+	engine     string
+	repo       string
+	version    string
 
 	autoApprove bool
 	// replace determine whether to replace an existing chart, the default value is false
@@ -75,13 +80,14 @@ func newRegisterOption(f cmdutil.Factory, streams genericiooptions.IOStreams) *r
 func newRegisterCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := newRegisterOption(f, streams)
 	cmd := &cobra.Command{
-		Use:     "register [NAME] --source [CHART-URL]",
+		Use:     "register [NAME]",
 		Short:   "Pull the cluster chart to the local cache and register the type to 'create' sub-command",
 		Example: clusterRegisterExample,
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			o.clusterType = cluster.ClusterType(args[0])
 			cmdutil.CheckErr(o.validate())
+			cmdutil.CheckErr(o.complete())
 			cmdutil.CheckErr(o.run())
 			fmt.Fprint(streams.Out, buildRegisterSuccessExamples(o.clusterType))
 		},
@@ -89,13 +95,14 @@ func newRegisterCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobr
 	cmd.Flags().StringVarP(&o.source, "source", "S", "", "Specify the cluster type chart source, support a URL or a local file path")
 	cmd.Flags().StringVar(&o.alias, "alias", "", "Set the cluster type alias")
 	cmd.Flags().BoolVar(&o.autoApprove, "auto-approve", false, "Skip interactive approval when registering an existed cluster type")
-
-	_ = cmd.MarkFlagRequired("source")
+	cmd.Flags().StringVar(&o.engine, "engine", "", "Specify the cluster chart name in helm repo")
+	cmd.Flags().StringVar(&o.repo, "repo", "", "Specify the url of  helm repo which contains cluster charts")
+	cmd.Flags().StringVar(&o.version, "version", "", "Specify the version of cluster chart to register")
 
 	return cmd
 }
 
-// validate will check the
+// validate will check the flags of command
 func (o *registerOption) validate() error {
 	re := regexp.MustCompile(`^[a-zA-Z0-9]{1,16}$`)
 	if !re.MatchString(o.clusterType.String()) {
@@ -114,11 +121,14 @@ func (o *registerOption) validate() error {
 		}
 	}
 
-	if validateSource(o.source) != nil {
-		return fmt.Errorf("your entered `--source` %s, which is neither a URL nor a file that can be found locally", o.source)
+	if !o.isSourceMethod() {
+		o.cachedName = fmt.Sprintf("%s-cluster-%s.tgz", o.engine, o.version)
+	} else {
+		if validateSource(o.source) != nil {
+			return fmt.Errorf("your entered `--source` %s, which is neither a URL nor a file that can be found locally", o.source)
+		}
+		o.cachedName = filepath.Base(o.source)
 	}
-
-	o.cachedName = filepath.Base(o.source)
 	if !o.replace {
 		// if not replace. we should check the chart name whether conflict in local cache
 		// if conflicted, we add a timestamp to the cached name
@@ -135,26 +145,48 @@ func (o *registerOption) validate() error {
 	return nil
 }
 
-func (o *registerOption) run() error {
+func (o *registerOption) complete() error {
+	if !o.isSourceMethod() {
+		if o.repo == "" {
+			o.repo = types.ClusterChartsRepoURL
+		}
+	}
+	return nil
+}
 
-	if govalidator.IsURL(o.source) {
-		// source is URL
-		chartsDownloader, err := helm.NewDownloader(helm.NewConfig("default", "", "", false))
-		if err != nil {
-			return err
+func (o *registerOption) run() error {
+	localChartPath := filepath.Join(cluster.CliChartsCacheDir, o.cachedName)
+	if o.isSourceMethod() {
+		if govalidator.IsURL(o.source) {
+			// source is URL
+			chartsDownloader, err := helm.NewDownloader(helm.NewConfig("default", "", "", false))
+			if err != nil {
+				return err
+			}
+			// DownloadTo can't specify the saved name, so download it to TempDir and rename it when copy
+			tempPath, _, err := chartsDownloader.DownloadTo(o.source, "", os.TempDir())
+			if err != nil {
+				return err
+			}
+			err = copyFile(tempPath, localChartPath)
+			if err != nil {
+				return err
+			}
+			_ = os.Remove(tempPath)
+		} else {
+			if err := copyFile(o.source, localChartPath); err != nil {
+				return err
+			}
 		}
-		// DownloadTo can't specify the saved name, so download it to TempDir and rename it when copy
-		tempPath, _, err := chartsDownloader.DownloadTo(o.source, "", os.TempDir())
-		if err != nil {
-			return err
-		}
-		err = copyFile(tempPath, filepath.Join(cluster.CliChartsCacheDir, o.cachedName))
-		if err != nil {
-			return err
-		}
-		_ = os.Remove(tempPath)
 	} else {
-		if err := copyFile(o.source, filepath.Join(cluster.CliChartsCacheDir, o.cachedName)); err != nil {
+		if err := helm.AddRepo(&repo.Entry{
+			Name: types.ClusterChartsRepoName,
+			URL:  o.repo,
+		}); err != nil {
+			return err
+		}
+		err := helm.PullChart(types.ClusterChartsRepoName, o.engine+"-cluster", o.version, cluster.CliChartsCacheDir)
+		if err != nil {
 			return err
 		}
 	}
@@ -195,6 +227,10 @@ func validateSource(source string) error {
 		return nil
 	}
 	return err
+}
+
+func (o *registerOption) isSourceMethod() bool {
+	return o.source == ""
 }
 
 func copyFile(src, dest string) error {

--- a/pkg/cmd/cluster/register.go
+++ b/pkg/cmd/cluster/register.go
@@ -46,7 +46,10 @@ var clusterRegisterExample = templates.Examples(`
 	kbcli cluster register orioledb --source https://github.com/apecloud/helm-charts/releases/download/orioledb-cluster-0.6.0-beta.44/orioledb-cluster-0.6.0-beta.44.tgz
 
 	# Register a cluster type from a local path file
-	kbcli cluster register neon -source pkg/cli/cluster/charts/neon-cluster.tgz
+	kbcli cluster register neon --source pkg/cli/cluster/charts/neon-cluster.tgz
+
+	# Register a cluster type from a Helm repository, specifying the version and engine.
+	kbcli cluster register mysql --engine mysql --version 0.9.0 --repo https://jihulab.com/api/v4/projects/150246/packages/helm/stable
 `)
 
 type registerOption struct {

--- a/pkg/cmd/cluster/register.go
+++ b/pkg/cmd/cluster/register.go
@@ -21,7 +21,6 @@ package cluster
 
 import (
 	"fmt"
-	"github.com/apecloud/kbcli/pkg/util/prompt"
 	"io"
 	"net/url"
 	"os"
@@ -114,20 +113,17 @@ func (o *registerOption) validate() error {
 			if key != o.clusterType {
 				continue
 			}
-			if err := prompt.Confirm(nil, o.In, fmt.Sprintf("Your register cluster type %s is already existed", o.clusterType), "Please type 'Yes/yes' to confirm your operation and replace the cluster chart:"); err != nil {
-				return err
-			}
 			o.replace = true
 		}
 	}
 
-	if !o.isSourceMethod() {
-		o.cachedName = fmt.Sprintf("%s-cluster-%s.tgz", o.engine, o.version)
-	} else {
+	if o.isSourceMethod() {
 		if validateSource(o.source) != nil {
 			return fmt.Errorf("your entered `--source` %s, which is neither a URL nor a file that can be found locally", o.source)
 		}
 		o.cachedName = filepath.Base(o.source)
+	} else {
+		o.cachedName = fmt.Sprintf("%s-cluster-%s.tgz", o.engine, o.version)
 	}
 	if !o.replace {
 		// if not replace. we should check the chart name whether conflict in local cache
@@ -231,7 +227,7 @@ func validateSource(source string) error {
 }
 
 func (o *registerOption) isSourceMethod() bool {
-	return o.source == ""
+	return o.source != ""
 }
 
 func copyFile(src, dest string) error {

--- a/pkg/cmd/cluster/register.go
+++ b/pkg/cmd/cluster/register.go
@@ -96,7 +96,7 @@ func newRegisterCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobr
 	cmd.Flags().StringVar(&o.alias, "alias", "", "Set the cluster type alias")
 	cmd.Flags().BoolVar(&o.autoApprove, "auto-approve", false, "Skip interactive approval when registering an existed cluster type")
 	cmd.Flags().StringVar(&o.engine, "engine", "", "Specify the cluster chart name in helm repo")
-	cmd.Flags().StringVar(&o.repo, "repo", "", "Specify the url of  helm repo which contains cluster charts")
+	cmd.Flags().StringVar(&o.repo, "repo", "", "Specify the url of helm repo which contains cluster charts")
 	cmd.Flags().StringVar(&o.version, "version", "", "Specify the version of cluster chart to register")
 
 	return cmd
@@ -179,6 +179,7 @@ func (o *registerOption) run() error {
 			}
 		}
 	} else {
+		// specify the url of the repo containing cluster charts, and add it as the repo name kubeblocks-addons
 		if err := helm.AddRepo(&repo.Entry{
 			Name: types.ClusterChartsRepoName,
 			URL:  o.repo,

--- a/pkg/cmd/cluster/register_test.go
+++ b/pkg/cmd/cluster/register_test.go
@@ -62,10 +62,6 @@ var _ = Describe("cluster register", func() {
 		}
 		Expect(o.validate()).Should(HaveOccurred())
 
-		o.clusterType = "mysql"
-		// builtin chart
-		Expect(o.validate()).Should(HaveOccurred())
-
 		o.clusterType = "oracle"
 		Expect(o.validate()).Should(Succeed())
 
@@ -81,9 +77,21 @@ var _ = Describe("cluster register", func() {
 		Expect(o.validate()).Should(Succeed())
 		o.source = "https://github.com/apecloud/helm-charts/releases/download/orioledb-cluster-0.6.0-beta.44/orioledb-cluster-0.6.0-beta.44.tgz"
 		Expect(o.validate()).Should(Succeed())
-		o.source = "This is a bad url or a local file path do not existed"
-		Expect(o.validate()).Should(HaveOccurred())
+	})
 
+	It("test validate method of repo, version and engine", func() {
+		o := &registerOption{
+			Factory:     tf,
+			IOStreams:   streams,
+			clusterType: "mysql",
+			version:     "0.9.0",
+			repo:        "https://jihulab.com/api/v4/projects/150246/packages/helm",
+			engine:      "mysql",
+			source:      "",
+		}
+		err := o.validate()
+		println(err)
+		Expect(err).Should(Succeed())
 	})
 
 	It("test copy file", func() {

--- a/pkg/cmd/cluster/register_test.go
+++ b/pkg/cmd/cluster/register_test.go
@@ -89,9 +89,7 @@ var _ = Describe("cluster register", func() {
 			engine:      "mysql",
 			source:      "",
 		}
-		err := o.validate()
-		println(err)
-		Expect(err).Should(Succeed())
+		Expect(o.validate()).Should(Succeed())
 	})
 
 	It("test copy file", func() {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -263,6 +263,12 @@ var (
 
 	// AddonIndexDir is the default addon index dir
 	AddonIndexDir = filepath.Join("addon", "index")
+
+	// ClusterChartsRepoName helm chart repo for installing cluster chart
+	ClusterChartsRepoName = "kubeblocks-addons"
+
+	// ClusterChartsRepoURL the default helm chart repo for installing cluster chart
+	ClusterChartsRepoURL = "https://jihulab.com/api/v4/projects/150246/packages/helm/stable"
 )
 
 // Playground

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -198,6 +198,23 @@ func (i *InstallOpts) Install(cfg *Config) (*release.Release, error) {
 	return rel, nil
 }
 
+func PullChart(repo string, chartName string, version string, destDir string) error {
+	actionCfg, err := NewActionConfig(NewConfig("", "", "", klog.V(1).Enabled()))
+	if err != nil {
+		return err
+	}
+	settings := cli.New()
+	client := action.NewPullWithOpts(action.WithConfig(actionCfg))
+	client.Settings = settings
+	client.RepoURL = ""
+	client.Version = version
+	client.DestDir = destDir
+	client.UntarDir = destDir
+	client.Untar = false
+	_, err = client.Run(repo + "/" + chartName)
+	return err
+}
+
 func (i *InstallOpts) tryInstall(cfg *action.Configuration) (*release.Release, error) {
 	if i.DryRun == nil || !*i.DryRun {
 		released, err := i.GetInstalled(cfg)

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -109,7 +109,7 @@ func AddRepo(r *repo.Entry) error {
 
 	if f.Has(r.Name) {
 		existing := f.Get(r.Name)
-		if *r != *existing && r.Name != types.KubeBlocksChartName {
+		if *r != *existing && r.Name != types.KubeBlocksRepoName && r.Name != types.ClusterChartsRepoName {
 			// The input Name is different from the existing one, return an error
 			return errors.Errorf("repository name (%s) already exists, please specify a different name", r.Name)
 		}


### PR DESCRIPTION
partly fixed: #420

what's changed:

1. Cluster register supports overriding the built-in chart, pulling by helm repo + engine + version, and validating schema standards.
2. Addon install and search support specifying a local path.
3. Addon install, enable, and upgrade support register the chart at the same time.
4. Addon uninstall also deletes the corresponding chart.
5. Addon search supports searching for all addons (including those not installed).
