### PR TITLE
feat: check helm release status before kubeblocks upgrade

### DIFF
--- a/pkg/cmd/kubeblocks/upgrade.go
+++ b/pkg/cmd/kubeblocks/upgrade.go
@@ -98,9 +98,11 @@ func (o *InstallOptions) Upgrade() error {
 	if err != nil {
 		return fmt.Errorf("failed to get Helm release status: %v", err)
 	}
-	// intercept status except from 'deployed'
-	if status != release.StatusDeployed {
-		return fmt.Errorf("helm release status is %s instead of 'deployed'. Please fix the release before upgrading KubeBlocks", status.String())
+	// intercept status of pending, unknown, uninstall and uninstalled.
+	if status.IsPending() {
+		return fmt.Errorf("helm release status is %s. Please wait until the release status changes to ‘deployed’ before upgrading KubeBlocks", status.String())
+	} else if status != release.StatusDeployed && status != release.StatusFailed && status != release.StatusSuperseded {
+		return fmt.Errorf("helm release status is %s. Please fix the release before upgrading KubeBlocks", status.String())
 	}
 
 	if o.HelmCfg.Namespace() == "" {

--- a/pkg/cmd/kubeblocks/upgrade.go
+++ b/pkg/cmd/kubeblocks/upgrade.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"helm.sh/helm/v3/pkg/release"
 	"time"
 
 	"github.com/hashicorp/go-version"
@@ -92,6 +93,15 @@ func newUpgradeCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 
 func (o *InstallOptions) Upgrade() error {
 	klog.V(1).Info("##### Start to upgrade KubeBlocks #####")
+	// check helm release status
+	status, err := helm.GetHelmReleaseStatus(o.HelmCfg, nil, types.KubeBlocksChartName)
+	if err != nil {
+		return fmt.Errorf("failed to get Helm release status: %v", err)
+	}
+	if status == release.StatusFailed {
+		return fmt.Errorf("helm release status is 'failed'. Please fix the release before upgrading KubeBlocks")
+	}
+
 	if o.HelmCfg.Namespace() == "" {
 		ns, err := util.GetKubeBlocksNamespace(o.Client)
 		if err != nil || ns == "" {

--- a/pkg/cmd/kubeblocks/upgrade.go
+++ b/pkg/cmd/kubeblocks/upgrade.go
@@ -98,7 +98,7 @@ func (o *InstallOptions) Upgrade() error {
 	if err != nil {
 		return fmt.Errorf("failed to get Helm release status: %v", err)
 	}
-	// intercept status of pending, unknown, uninstall and uninstalled.
+	// intercept status of pending, unknown, uninstalling and uninstalled.
 	if status.IsPending() {
 		return fmt.Errorf("helm release status is %s. Please wait until the release status changes to ‘deployed’ before upgrading KubeBlocks", status.String())
 	} else if status != release.StatusDeployed && status != release.StatusFailed && status != release.StatusSuperseded {

--- a/pkg/cmd/kubeblocks/upgrade.go
+++ b/pkg/cmd/kubeblocks/upgrade.go
@@ -100,7 +100,7 @@ func (o *InstallOptions) Upgrade() error {
 	}
 	// intercept status except from 'deployed'
 	if status != release.StatusDeployed {
-		return fmt.Errorf("helm release status is %s instead of 'deployed'. Please fix the release before upgrading KubeBlocks", status)
+		return fmt.Errorf("helm release status is %s instead of 'deployed'. Please fix the release before upgrading KubeBlocks", status.String())
 	}
 
 	if o.HelmCfg.Namespace() == "" {

--- a/pkg/cmd/kubeblocks/upgrade_test.go
+++ b/pkg/cmd/kubeblocks/upgrade_test.go
@@ -184,10 +184,10 @@ var _ = Describe("kubeblocks upgrade", func() {
 				checkResult bool
 			}{
 				{release.StatusDeployed, true},
-				{release.StatusSuperseded, false},
+				{release.StatusSuperseded, true},
+				{release.StatusFailed, true},
 				{release.StatusUnknown, false},
 				{release.StatusUninstalled, false},
-				{release.StatusFailed, false},
 				{release.StatusUninstalling, false},
 				{release.StatusPendingInstall, false},
 				{release.StatusPendingUpgrade, false},

--- a/pkg/cmd/kubeblocks/upgrade_test.go
+++ b/pkg/cmd/kubeblocks/upgrade_test.go
@@ -45,110 +45,187 @@ var _ = Describe("kubeblocks upgrade", func() {
 	var actionCfg *action.Configuration
 	var cfg *helm.Config
 
-	BeforeEach(func() {
-		streams, _, _, _ = genericiooptions.NewTestIOStreams()
-		tf = cmdtesting.NewTestFactory().WithNamespace(namespace)
-		tf.Client = &clientfake.RESTClient{}
-	})
+	Context("Upgrade", func() {
+		BeforeEach(func() {
+			streams, _, _, _ = genericiooptions.NewTestIOStreams()
+			tf = cmdtesting.NewTestFactory().WithNamespace(namespace)
+			tf.Client = &clientfake.RESTClient{}
+			cfg = helm.NewFakeConfig(namespace)
+			actionCfg, _ = helm.NewActionConfig(cfg)
+			err := actionCfg.Releases.Create(&release.Release{
+				Name:      testing.KubeBlocksChartName,
+				Namespace: namespace,
+				Version:   1,
+				Info: &release.Info{
+					Status: release.StatusDeployed,
+				},
+				Chart: &chart.Chart{},
+			})
+			Expect(err).Should(BeNil())
 
-	AfterEach(func() {
-		tf.Cleanup()
-	})
-
-	mockKubeBlocksDeploy := func() *appsv1.Deployment {
-		deploy := &appsv1.Deployment{}
-		deploy.SetLabels(map[string]string{
-			"app.kubernetes.io/component": "apps",
-			"app.kubernetes.io/name":      types.KubeBlocksChartName,
-			"app.kubernetes.io/version":   "0.3.0",
 		})
-		return deploy
-	}
 
-	It("check upgrade", func() {
-		var cfg string
-		cmd = newUpgradeCmd(tf, streams)
-		Expect(cmd).ShouldNot(BeNil())
-		Expect(cmd.HasSubCommands()).Should(BeFalse())
-
-		o := &InstallOptions{
-			Options: Options{
-				IOStreams: streams,
-			},
-		}
-
-		By("command without kubeconfig flag")
-		Expect(o.Complete(tf, cmd)).Should(HaveOccurred())
-
-		cmd.Flags().StringVar(&cfg, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
-		cmd.Flags().StringVar(&cfg, "context", "", "The name of the kubeconfig context to use.")
-		Expect(o.Complete(tf, cmd)).To(Succeed())
-		Expect(o.HelmCfg).ShouldNot(BeNil())
-		Expect(o.Namespace).To(Equal("test"))
-	})
-
-	It("double-check when version change", func() {
-		o := &InstallOptions{
-			Options: Options{
-				IOStreams: streams,
-				HelmCfg:   helm.NewFakeConfig(namespace),
-				Namespace: "default",
-				Client:    testing.FakeClientSet(mockKubeBlocksDeploy()),
-				Dynamic:   testing.FakeDynamicClient(),
-			},
-			Version: "0.5.0-fake",
-			Check:   false,
-		}
-		Expect(o.Upgrade()).Should(HaveOccurred())
-		// o.In = bytes.NewBufferString("fake-version") mock input error
-		// Expect(o.Upgrade()).Should(Succeed())
-		o.autoApprove = true
-		Expect(o.Upgrade()).Should(Succeed())
-
-	})
-
-	It("helm ValueOpts upgrade", func() {
-		o := &InstallOptions{
-			Options: Options{
-				IOStreams: streams,
-				HelmCfg:   helm.NewFakeConfig(namespace),
-				Namespace: "default",
-				Client:    testing.FakeClientSet(mockKubeBlocksDeploy()),
-				Dynamic:   testing.FakeDynamicClient(),
-			},
-			Version: "",
-		}
-		o.ValueOpts.Values = []string{"replicaCount=2"}
-		Expect(o.Upgrade()).Should(Succeed())
-	})
-
-	It("run upgrade", func() {
-		cfg = helm.NewFakeConfig(namespace)
-		actionCfg, _ = helm.NewActionConfig(cfg)
-		err := actionCfg.Releases.Create(&release.Release{
-			Name:      testing.KubeBlocksChartName,
-			Namespace: namespace,
-			Version:   1,
-			Info: &release.Info{
-				Status: release.StatusDeployed,
-			},
-			Chart: &chart.Chart{},
+		AfterEach(func() {
+			helm.ResetFakeActionConfig()
+			tf.Cleanup()
 		})
-		Expect(err).Should(BeNil())
 
-		o := &InstallOptions{
-			Options: Options{
-				IOStreams: streams,
-				HelmCfg:   cfg,
-				Namespace: "default",
-				Client:    testing.FakeClientSet(mockKubeBlocksDeploy()),
-				Dynamic:   testing.FakeDynamicClient(),
-			},
-			Version: version.DefaultKubeBlocksVersion,
-			Check:   false,
+		mockKubeBlocksDeploy := func() *appsv1.Deployment {
+			deploy := &appsv1.Deployment{}
+			deploy.SetLabels(map[string]string{
+				"app.kubernetes.io/component": "apps",
+				"app.kubernetes.io/name":      types.KubeBlocksChartName,
+				"app.kubernetes.io/version":   "0.3.0",
+			})
+			return deploy
 		}
-		Expect(o.Upgrade()).Should(Succeed())
-		Expect(len(o.ValueOpts.Values)).To(Equal(0))
-		Expect(o.upgradeChart()).Should(Succeed())
+
+		It("check upgrade", func() {
+			var cfg string
+			cmd = newUpgradeCmd(tf, streams)
+			Expect(cmd).ShouldNot(BeNil())
+			Expect(cmd.HasSubCommands()).Should(BeFalse())
+
+			o := &InstallOptions{
+				Options: Options{
+					IOStreams: streams,
+				},
+			}
+
+			By("command without kubeconfig flag")
+			Expect(o.Complete(tf, cmd)).Should(HaveOccurred())
+
+			cmd.Flags().StringVar(&cfg, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+			cmd.Flags().StringVar(&cfg, "context", "", "The name of the kubeconfig context to use.")
+			Expect(o.Complete(tf, cmd)).To(Succeed())
+			Expect(o.HelmCfg).ShouldNot(BeNil())
+			Expect(o.Namespace).To(Equal("test"))
+		})
+
+		It("double-check when version change", func() {
+			o := &InstallOptions{
+				Options: Options{
+					IOStreams: streams,
+					HelmCfg:   helm.NewFakeConfig(namespace),
+					Namespace: "default",
+					Client:    testing.FakeClientSet(mockKubeBlocksDeploy()),
+					Dynamic:   testing.FakeDynamicClient(),
+				},
+				Version: "0.5.0-fake",
+				Check:   false,
+			}
+			Expect(o.Upgrade()).Should(HaveOccurred())
+			// o.In = bytes.NewBufferString("fake-version") mock input error
+			// Expect(o.Upgrade()).Should(Succeed())
+			o.autoApprove = true
+			Expect(o.Upgrade()).Should(Succeed())
+
+		})
+
+		It("helm ValueOpts upgrade", func() {
+			o := &InstallOptions{
+				Options: Options{
+					IOStreams: streams,
+					HelmCfg:   helm.NewFakeConfig(namespace),
+					Namespace: "default",
+					Client:    testing.FakeClientSet(mockKubeBlocksDeploy()),
+					Dynamic:   testing.FakeDynamicClient(),
+				},
+				Version: "",
+			}
+			o.ValueOpts.Values = []string{"replicaCount=2"}
+			Expect(o.Upgrade()).Should(Succeed())
+		})
+
+		It("run upgrade", func() {
+			o := &InstallOptions{
+				Options: Options{
+					IOStreams: streams,
+					HelmCfg:   cfg,
+					Namespace: "default",
+					Client:    testing.FakeClientSet(mockKubeBlocksDeploy()),
+					Dynamic:   testing.FakeDynamicClient(),
+				},
+				Version: version.DefaultKubeBlocksVersion,
+				Check:   false,
+			}
+			Expect(o.Upgrade()).Should(Succeed())
+			Expect(len(o.ValueOpts.Values)).To(Equal(0))
+			Expect(o.upgradeChart()).Should(Succeed())
+		})
 	})
+
+	Context("upgrade from different status", func() {
+		BeforeEach(func() {
+			streams, _, _, _ = genericiooptions.NewTestIOStreams()
+			tf = cmdtesting.NewTestFactory().WithNamespace(namespace)
+			tf.Client = &clientfake.RESTClient{}
+			cfg = helm.NewFakeConfig(namespace)
+			actionCfg, _ = helm.NewActionConfig(cfg)
+		})
+
+		AfterEach(func() {
+			helm.ResetFakeActionConfig()
+			tf.Cleanup()
+		})
+
+		mockKubeBlocksDeploy := func() *appsv1.Deployment {
+			deploy := &appsv1.Deployment{}
+			deploy.SetLabels(map[string]string{
+				"app.kubernetes.io/component": "apps",
+				"app.kubernetes.io/name":      types.KubeBlocksChartName,
+				"app.kubernetes.io/version":   "0.3.0",
+			})
+			return deploy
+		}
+		It("run upgrade", func() {
+			testCase := []struct {
+				status      release.Status
+				checkResult bool
+			}{
+				{release.StatusDeployed, true},
+				{release.StatusSuperseded, false},
+				{release.StatusUnknown, false},
+				{release.StatusUninstalled, false},
+				{release.StatusFailed, false},
+				{release.StatusUninstalling, false},
+				{release.StatusPendingInstall, false},
+				{release.StatusPendingUpgrade, false},
+				{release.StatusPendingRollback, false},
+			}
+
+			for i := range testCase {
+				actionCfg, _ = helm.NewActionConfig(cfg)
+				err := actionCfg.Releases.Create(&release.Release{
+					Name:      testing.KubeBlocksChartName,
+					Namespace: namespace,
+					Version:   1,
+					Info: &release.Info{
+						Status: testCase[i].status,
+					},
+					Chart: &chart.Chart{},
+				})
+				Expect(err).Should(BeNil())
+				o := &InstallOptions{
+					Options: Options{
+						IOStreams: streams,
+						HelmCfg:   cfg,
+						Namespace: "default",
+						Client:    testing.FakeClientSet(mockKubeBlocksDeploy()),
+						Dynamic:   testing.FakeDynamicClient(),
+					},
+					Version: version.DefaultKubeBlocksVersion,
+					Check:   false,
+				}
+				if testCase[i].checkResult {
+					Expect(o.Upgrade()).Should(Succeed())
+				} else {
+					Expect(o.Upgrade()).Should(HaveOccurred())
+				}
+				helm.ResetFakeActionConfig()
+			}
+
+		})
+	})
+
 })

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -690,3 +690,20 @@ func GetTemplateInstallOps(name, chart, version, namespace string) *InstallOpts 
 		DryRun:     &dryrun,
 	}
 }
+
+// GetHelmReleaseStatus retrieves the status of a Helm release within a specified namespace.
+func GetHelmReleaseStatus(cfg *Config, actionCfg *action.Configuration, releaseName string) (release.Status, error) {
+	var err error
+	if actionCfg == nil {
+		actionCfg, err = NewActionConfig(cfg)
+		if err != nil {
+			return "", err
+		}
+	}
+	client := action.NewGet(actionCfg)
+	rel, err := client.Run(releaseName)
+	if err != nil {
+		return "", err
+	}
+	return rel.Info.Status, nil
+}

--- a/pkg/util/helm/helm_test.go
+++ b/pkg/util/helm/helm_test.go
@@ -153,26 +153,41 @@ var _ = Describe("helm util", func() {
 			Expect(errors.Is(err, ErrReleaseNotDeployed)).Should(BeTrue())
 			Expect(o.tryUninstall(actionCfg)).Should(BeNil()) // release exists
 		})
-
-		It("get helm release status", func() {
-			err := actionCfg.Releases.Create(&release.Release{
-				Name:    o.Name,
-				Version: 1,
-				Info: &release.Info{
-					Status: release.StatusFailed,
-				},
-				Chart: &chart.Chart{},
-			})
-			Expect(err).Should(BeNil())
-			_, _ = GetValues("", cfg)
-			status, err := GetHelmReleaseStatus(cfg, actionCfg, o.Name)
-			Expect(status).Should(Equal(release.StatusFailed))
-			Expect(err).Should(BeNil())
-		})
 	})
 
 	It("get chart versions", func() {
 		versions, _ := GetChartVersions(testing.KubeBlocksChartName)
 		Expect(versions).Should(BeNil())
 	})
+
+	It("get helm release status", func() {
+		var o *InstallOpts
+		var cfg *Config
+		var actionCfg *action.Configuration
+
+		o = &InstallOpts{
+			Name:      types.KubeBlocksChartName,
+			Chart:     "kubeblocks-test-chart",
+			Namespace: "default",
+			Version:   version.DefaultKubeBlocksVersion,
+		}
+		cfg = NewFakeConfig("default")
+		actionCfg, _ = NewActionConfig(cfg)
+		Expect(actionCfg).ShouldNot(BeNil())
+
+		err := actionCfg.Releases.Create(&release.Release{
+			Name:    o.Name,
+			Version: 1,
+			Info: &release.Info{
+				Status: release.StatusFailed,
+			},
+			Chart: &chart.Chart{},
+		})
+		Expect(err).Should(BeNil())
+		_, _ = GetValues("", cfg)
+		status, err := GetHelmReleaseStatus(cfg, actionCfg, o.Name)
+		Expect(status).Should(Equal(release.StatusFailed))
+		Expect(err).Should(BeNil())
+	})
+
 })

--- a/pkg/util/helm/helm_test.go
+++ b/pkg/util/helm/helm_test.go
@@ -68,6 +68,10 @@ var _ = Describe("helm util", func() {
 			Expect(actionCfg).ShouldNot(BeNil())
 		})
 
+		AfterEach(func() {
+			ResetFakeActionConfig()
+		})
+
 		It("Install", func() {
 			_, err := o.Install(cfg)
 			Expect(err).Should(HaveOccurred())
@@ -117,6 +121,10 @@ var _ = Describe("helm util", func() {
 			cfg = NewFakeConfig("default")
 			actionCfg, _ = NewActionConfig(cfg)
 			Expect(actionCfg).ShouldNot(BeNil())
+		})
+
+		AfterEach(func() {
+			ResetFakeActionConfig()
 		})
 
 		It("should fail when release is not found", func() {
@@ -185,9 +193,10 @@ var _ = Describe("helm util", func() {
 		})
 		Expect(err).Should(BeNil())
 		_, _ = GetValues("", cfg)
-		status, err := GetHelmReleaseStatus(cfg, actionCfg, o.Name)
+		status, err := GetHelmReleaseStatus(cfg, o.Name)
 		Expect(status).Should(Equal(release.StatusFailed))
 		Expect(err).Should(BeNil())
+		ResetFakeActionConfig()
 	})
 
 })

--- a/pkg/util/helm/helm_test.go
+++ b/pkg/util/helm/helm_test.go
@@ -153,6 +153,22 @@ var _ = Describe("helm util", func() {
 			Expect(errors.Is(err, ErrReleaseNotDeployed)).Should(BeTrue())
 			Expect(o.tryUninstall(actionCfg)).Should(BeNil()) // release exists
 		})
+
+		It("get helm release status", func() {
+			err := actionCfg.Releases.Create(&release.Release{
+				Name:    o.Name,
+				Version: 1,
+				Info: &release.Info{
+					Status: release.StatusFailed,
+				},
+				Chart: &chart.Chart{},
+			})
+			Expect(err).Should(BeNil())
+			_, _ = GetValues("", cfg)
+			status, err := GetHelmReleaseStatus(cfg, actionCfg, o.Name)
+			Expect(status).Should(Equal(release.StatusFailed))
+			Expect(err).Should(BeNil())
+		})
 	})
 
 	It("get chart versions", func() {


### PR DESCRIPTION
fix #398
Refer to [helm upgrade](https://github.com/helm/helm/blob/e81f6140ddb22bc99a08f7409522a8dbe5338ee3/pkg/action/upgrade.go#L204-L224)
Check the release status of Kubeblocks before upgrade. Upgrade will run correctly only if the status is one of 'deployed', 'failed' and 'superseded' .