### PR TITLE
feat: addon install require to specify the version

### DIFF
--- a/docs/user_docs/cli/kbcli_addon_install.md
+++ b/docs/user_docs/cli/kbcli_addon_install.md
@@ -39,7 +39,7 @@ kbcli addon install [flags]
   -h, --help                           help for install
       --index string                   specify the addon index, use 'kubeblocks' by default (default "kubeblocks")
       --path string                    specify the local path contains addon CRs and needs to be specified when operating offline
-      --version string                 specify the addon version
+      --version string                 specify the addon version to install, run 'kbcli addon search <addon-name>' to get the available versions
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_addon_search.md
+++ b/docs/user_docs/cli/kbcli_addon_search.md
@@ -11,23 +11,14 @@ kbcli addon search [flags]
 ### Examples
 
 ```
-  # install an addon from default index
-  kbcli addon install apecloud-mysql
+  # search the addons of all index
+  kbcli addon search
   
-  # install an addon from default index and skip KubeBlocks version compatibility check
-  kbcli addon install apecloud-mysql --force
+  # search the addons from a specified local path
+  kbcli addon search --path /path/to/local/chart
   
-  # install an addon from a specified index
-  kbcli addon install apecloud-mysql --index my-index
-  
-  # install an addon with a specified version default index
-  kbcli addon install apecloud-mysql --version 0.7.0
-  
-  # install an addon with a specified version and cluster chart of different version.
-  kbcli addon install apecloud-mysql --version 0.7.0 --cluster-chart-version 0.7.1
-  
-  # install an addon with a specified version and local path.
-  kbcli addon install apecloud-mysql --version 0.7.0 --path /path/to/local/chart
+  # search different versions and indexes of an addon
+  kbcli addon search apecloud-mysql
 ```
 
 ### Options

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -144,11 +144,13 @@ func newInstallCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 		},
 	}
 	cmd.Flags().BoolVar(&o.force, "force", false, "force install the addon and ignore the version check")
-	cmd.Flags().StringVar(&o.version, "version", "", "specify the addon version")
+	cmd.Flags().StringVar(&o.version, "version", "", "specify the addon version to install, run 'kbcli addon search <addon-name>' to get the available versions")
 	cmd.Flags().StringVar(&o.index, "index", types.DefaultIndexName, "specify the addon index, use 'kubeblocks' by default")
 	cmd.Flags().StringVar(&o.clusterChartVersion, "cluster-chart-version", "", "specify the cluster chart version, use the same version as the addon by default")
 	cmd.Flags().StringVar(&o.clusterChartRepo, "cluster-chart-repo", types.ClusterChartsRepoURL, "specify the repo of cluster chart, use the url of 'kubeblocks-addons' by default")
 	cmd.Flags().StringVar(&o.path, "path", "", "specify the local path contains addon CRs and needs to be specified when operating offline")
+
+	_ = cmd.MarkFlagRequired("version")
 
 	return cmd
 }
@@ -163,6 +165,11 @@ func (o *installOption) Complete() error {
 	if err = o.baseOption.complete(); err != nil {
 		return err
 	}
+
+	if o.version == "" {
+		return fmt.Errorf("please specify the version, run 'kbcli addon search %s' to get the available versions", o.name)
+	}
+
 	// search specified addon and match its index
 	if _, err = semver.NewVersion(o.version); err != nil && o.version != "" {
 		return fmt.Errorf("the version %s does not comply with the standards", o.version)
@@ -196,12 +203,7 @@ func (o *installOption) Complete() error {
 	// descending order of versions
 	for _, item := range addons {
 		if o.path != "" || item.index.name == o.index {
-			// if the version not specified, use the latest version
-			if o.version == "" {
-				o.addon = item.addon
-				o.version = getAddonVersion(item.addon)
-				break
-			} else if o.version == getAddonVersion(item.addon) {
+			if o.version == getAddonVersion(item.addon) {
 				o.addon = item.addon
 				break
 			}
@@ -215,9 +217,7 @@ func (o *installOption) Complete() error {
 
 	if o.addon == nil {
 		var addonInfo = o.name
-		if o.version != "" {
-			addonInfo += "-" + o.version
-		}
+		addonInfo += "-" + o.version
 		return fmt.Errorf("addon '%s' not found in the index '%s'", addonInfo, o.index)
 	}
 	return nil
@@ -271,7 +271,7 @@ func (o *installOption) Run(f cmdutil.Factory, streams genericiooptions.IOStream
 // 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
 // https://semver.org/
 func validateVersion(annotations, kbVersion string) (bool, error) {
-	// if kb version is a prerelease version, we will break the rules for developing
+	// if kb version is a pre-release version, we will break the rules for developing
 	if strings.Contains(kbVersion, "-") {
 		addPreReleaseInfo := func(constrain string) string {
 			constrain = strings.Trim(constrain, " ")

--- a/pkg/cmd/addon/search.go
+++ b/pkg/cmd/addon/search.go
@@ -72,7 +72,7 @@ func newSearchCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 	cmd := &cobra.Command{
 		Use:     "search",
 		Short:   "Search the addon from index",
-		Example: addonInstallExample,
+		Example: addonSearchExample,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			util.CheckErr(util.EnableLogToFile(cmd.Flags()))
 			util.CheckErr(addDefaultIndex())

--- a/pkg/cmd/addon/upgrade_test.go
+++ b/pkg/cmd/addon/upgrade_test.go
@@ -67,6 +67,7 @@ var _ = Describe("test addon upgrade", func() {
 		tf.FakeDynamicClient = testing.FakeDynamicClient(testing.FakeAddon("apecloud-mysql"))
 		option = newUpgradeOption(tf, streams)
 		option.name = "apecloud-mysql"
+		option.version = "0.7.0"
 		Expect(option.Complete()).Should(Succeed())
 	})
 

--- a/pkg/util/breakingchange/upgradehandlerto0.7.go
+++ b/pkg/util/breakingchange/upgradehandlerto0.7.go
@@ -33,9 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/apecloud/kbcli/pkg/types"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+
+	"github.com/apecloud/kbcli/pkg/types"
 )
 
 var _ upgradeHandler = &upgradeHandlerTo7{}


### PR DESCRIPTION
* resolve https://github.com/apecloud/kbcli/issues/456

```
bin/kbcli addon install mysql
error: required flag(s) "version" not set

bin/kbcli addon install mysql --version=""
error: please specify the version, run 'kbcli addon search mysql' to get the available versions
```