### PR TITLE
chore: support ops-def list and describe

### DIFF
--- a/docs/user_docs/cli/cli.md
+++ b/docs/user_docs/cli/cli.md
@@ -146,6 +146,14 @@ KubeBlocks operation commands.
 * [kbcli kubeblocks upgrade](kbcli_kubeblocks_upgrade.md)	 - Upgrade KubeBlocks.
 
 
+## [ops-definition](kbcli_ops-definition.md)
+
+ops-definitions command.
+
+* [kbcli ops-definition describe](kbcli_ops-definition_describe.md)	 - Describe OpsDefinition.
+* [kbcli ops-definition list](kbcli_ops-definition_list.md)	 - List OpsDefinition.
+
+
 ## [options](kbcli_options.md)
 
 Print the list of flags inherited by all commands.

--- a/docs/user_docs/cli/kbcli.md
+++ b/docs/user_docs/cli/kbcli.md
@@ -63,6 +63,7 @@ kbcli [flags]
 * [kbcli dashboard](kbcli_dashboard.md)	 - List and open the KubeBlocks dashboards.
 * [kbcli dataprotection](kbcli_dataprotection.md)	 - Data protection command.
 * [kbcli kubeblocks](kbcli_kubeblocks.md)	 - KubeBlocks operation commands.
+* [kbcli ops-definition](kbcli_ops-definition.md)	 - ops-definitions command.
 * [kbcli options](kbcli_options.md)	 - Print the list of flags inherited by all commands.
 * [kbcli playground](kbcli_playground.md)	 - Bootstrap or destroy a playground KubeBlocks in local host or cloud.
 * [kbcli plugin](kbcli_plugin.md)	 - Provides utilities for interacting with plugins.

--- a/pkg/cmd/cli.go
+++ b/pkg/cmd/cli.go
@@ -47,6 +47,7 @@ import (
 	"github.com/apecloud/kbcli/pkg/cmd/dashboard"
 	"github.com/apecloud/kbcli/pkg/cmd/dataprotection"
 	"github.com/apecloud/kbcli/pkg/cmd/kubeblocks"
+	"github.com/apecloud/kbcli/pkg/cmd/opsdefinition"
 	"github.com/apecloud/kbcli/pkg/cmd/options"
 	"github.com/apecloud/kbcli/pkg/cmd/playground"
 	"github.com/apecloud/kbcli/pkg/cmd/plugin"
@@ -174,6 +175,7 @@ A Command Line Interface for KubeBlocks`,
 		clusterdefinition.NewClusterDefinitionCmd(f, ioStreams),
 		componentdefinition.NewComponentDefinitionCmd(f, ioStreams),
 		componentversion.NewComponentVersionCmd(f, ioStreams),
+		opsdefinition.NewOpsDefinitionCmd(f, ioStreams),
 		addon.NewAddonCmd(f, ioStreams),
 		plugin.NewPluginCmd(ioStreams),
 		report.NewReportCmd(f, ioStreams),

--- a/pkg/cmd/clusterdefinition/describe.go
+++ b/pkg/cmd/clusterdefinition/describe.go
@@ -101,7 +101,7 @@ func (o *describeOptions) complete(args []string) error {
 func (o *describeOptions) run() error {
 	for _, name := range o.names {
 		if err := o.describeClusterDef(name); err != nil {
-			return err
+			return fmt.Errorf("error describing clusterDefinitions '%s': %w", name, err)
 		}
 	}
 	return nil

--- a/pkg/cmd/componentdefinition/componnetdefinition.go
+++ b/pkg/cmd/componentdefinition/componnetdefinition.go
@@ -42,7 +42,7 @@ var listExample = templates.Examples(`
 		kbcli componentdefinition list
 	
 		# list all ComponentDefinitions by alias
-		kbcli componentdefinition list
+		kbcli cmpd list
 `)
 
 func NewComponentDefinitionCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {

--- a/pkg/cmd/componentdefinition/describe.go
+++ b/pkg/cmd/componentdefinition/describe.go
@@ -79,7 +79,7 @@ func (o *describeOptions) complete(args []string) error {
 	var err error
 
 	if len(args) == 0 {
-		return fmt.Errorf("compinent definition name should be specified")
+		return fmt.Errorf("component definition name should be specified")
 	}
 	o.names = args
 

--- a/pkg/cmd/componentdefinition/describe.go
+++ b/pkg/cmd/componentdefinition/describe.go
@@ -101,7 +101,7 @@ func (o *describeOptions) complete(args []string) error {
 func (o *describeOptions) run() error {
 	for _, name := range o.names {
 		if err := o.describeCmpd(name); err != nil {
-			return err
+			return fmt.Errorf("error describing componentDefinitions '%s': %w", name, err)
 		}
 	}
 	return nil

--- a/pkg/cmd/componentversion/describe.go
+++ b/pkg/cmd/componentversion/describe.go
@@ -96,7 +96,7 @@ func (o *describeOptions) complete(args []string) error {
 func (o *describeOptions) run() error {
 	for _, name := range o.names {
 		if err := o.describeCmpv(name); err != nil {
-			return err
+			return fmt.Errorf("error describing componentVersions '%s': %w", name, err)
 		}
 	}
 	return nil

--- a/pkg/cmd/componentversion/describe.go
+++ b/pkg/cmd/componentversion/describe.go
@@ -74,7 +74,7 @@ func (o *describeOptions) complete(args []string) error {
 	var err error
 
 	if len(args) == 0 {
-		return fmt.Errorf("compinent definition name should be specified")
+		return fmt.Errorf("component version name should be specified")
 	}
 	o.names = args
 
@@ -95,14 +95,14 @@ func (o *describeOptions) complete(args []string) error {
 
 func (o *describeOptions) run() error {
 	for _, name := range o.names {
-		if err := o.describeCmpd(name); err != nil {
+		if err := o.describeCmpv(name); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (o *describeOptions) describeCmpd(name string) error {
+func (o *describeOptions) describeCmpv(name string) error {
 	// get component version
 	cmpv := &kbappsv1.ComponentVersion{}
 	if err := util.GetK8SClientObject(o.dynamic, cmpv, types.ComponentVersionsGVR(), "", name); err != nil {

--- a/pkg/cmd/opsdefinition/describe.go
+++ b/pkg/cmd/opsdefinition/describe.go
@@ -1,0 +1,261 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opsdefinition
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+
+	"github.com/apecloud/kbcli/pkg/printer"
+	"github.com/apecloud/kbcli/pkg/types"
+	"github.com/apecloud/kbcli/pkg/util"
+)
+
+var (
+	describeExample = templates.Examples(`
+		# describe a specified ops-definition
+		kbcli ops-definition describe my-ops-definition`)
+)
+
+type describeOptions struct {
+	factory   cmdutil.Factory
+	client    clientset.Interface
+	dynamic   dynamic.Interface
+	namespace string
+
+	names []string
+	genericiooptions.IOStreams
+}
+
+func NewDescribeCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	o := &describeOptions{
+		factory:   f,
+		IOStreams: streams,
+	}
+	cmd := &cobra.Command{
+		Use:               "describe",
+		Short:             "Describe OpsDefinition.",
+		Example:           describeExample,
+		Aliases:           []string{"desc"},
+		ValidArgsFunction: util.ResourceNameCompletionFunc(f, types.OpsDefinitionGVR()),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.complete(args))
+			cmdutil.CheckErr(o.run())
+		},
+	}
+	return cmd
+}
+
+func (o *describeOptions) complete(args []string) error {
+	var err error
+
+	if len(args) == 0 {
+		return fmt.Errorf("component definition name should be specified")
+	}
+	o.names = args
+
+	if o.client, err = o.factory.KubernetesClientSet(); err != nil {
+		return err
+	}
+
+	if o.dynamic, err = o.factory.DynamicClient(); err != nil {
+		return err
+	}
+
+	if o.namespace, _, err = o.factory.ToRawKubeConfigLoader().Namespace(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *describeOptions) run() error {
+	for _, name := range o.names {
+		if err := o.describeOpsDef(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *describeOptions) describeOpsDef(name string) error {
+	// get ops definition
+	opsDef := &v1alpha1.OpsDefinition{}
+	if err := util.GetK8SClientObject(o.dynamic, opsDef, types.OpsDefinitionGVR(), "", name); err != nil {
+		return err
+	}
+
+	if err := o.showOpsDef(opsDef); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *describeOptions) showOpsDef(opsDef *v1alpha1.OpsDefinition) error {
+	printer.PrintPairStringToLine("Name", opsDef.Name, 0)
+
+	showComponentInfos(&opsDef.Spec.ComponentInfos, o.Out)
+	showPreConditions(&opsDef.Spec.PreConditions, o.Out)
+	showActions(&opsDef.Spec.Actions, o.Out)
+	showParametersSchema(opsDef.Spec.ParametersSchema, o.Out)
+	showPodInfoExtractors(&opsDef.Spec.PodInfoExtractors, o.Out)
+
+	printer.PrintPairStringToLine("Status", string(opsDef.Status.Phase), 0)
+	if opsDef.Status.Message != "" {
+		printer.PrintPairStringToLine("Message", opsDef.Status.Message, 0)
+	}
+	return nil
+}
+
+func showPreConditions(preConditions *[]v1alpha1.PreCondition, out io.Writer) {
+	if len(*preConditions) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "PreConditions:\n")
+	tbl := printer.NewTablePrinter(out)
+	tbl.SetHeader("\tEXPRESSION", "MESSAGE")
+	for _, preCondition := range *preConditions {
+		tbl.AddRow("\t"+preCondition.Rule.Expression, preCondition.Rule.Message)
+	}
+	tbl.Print()
+	fmt.Fprint(out, "\n")
+}
+
+func showComponentInfos(compInfos *[]v1alpha1.ComponentInfo, out io.Writer) {
+	if len(*compInfos) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "ComponentInfos:\n")
+	tbl := printer.NewTablePrinter(out)
+	tbl.SetHeader("\tCOMPONENT-DEF-NAME", "ACCOUNT-NAME", "SERVICE-NAME")
+	for _, compInfo := range *compInfos {
+		tbl.AddRow("\t"+compInfo.ComponentDefinitionName, compInfo.AccountName, compInfo.ServiceName)
+	}
+	tbl.Print()
+	fmt.Fprint(out, "\n")
+}
+
+func showActions(actions *[]v1alpha1.OpsAction, out io.Writer) {
+	if len(*actions) == 0 {
+		fmt.Fprintln(out, "No Actions defined.")
+		return
+	}
+	fmt.Fprintf(out, "Actions:\n")
+	tbl := printer.NewTablePrinter(out)
+	tbl.SetHeader("\tNAME", "TYPE", "FAILURE POLICY", "PARAMETERS")
+
+	for _, action := range *actions {
+		actionType := ""
+		params := strings.Join(action.Parameters, ", ")
+		switch {
+		case action.Workload != nil:
+			actionType = "Workload"
+		case action.Exec != nil:
+			actionType = "Exec"
+		case action.ResourceModifier != nil:
+			actionType = "ResourceModifier"
+		}
+		if params == "" {
+			params = "None"
+		}
+
+		tbl.AddRow("\t"+action.Name, actionType, string(action.FailurePolicy), params)
+	}
+	tbl.Print()
+	fmt.Fprint(out, "\n")
+}
+
+func showParametersSchema(schema *v1alpha1.ParametersSchema, out io.Writer) {
+	if schema == nil || schema.OpenAPIV3Schema == nil {
+		return
+	}
+	fmt.Fprintf(out, "Parameters Schema:\n")
+	schemaJSON, err := json.MarshalIndent(schema.OpenAPIV3Schema, "", "  ")
+	if err != nil {
+		fmt.Fprintf(out, "\tError: %v\n", err)
+		return
+	}
+	fmt.Fprintf(out, "%s\n", string(schemaJSON))
+}
+
+func showPodInfoExtractors(extractors *[]v1alpha1.PodInfoExtractor, out io.Writer) {
+	if len(*extractors) == 0 {
+		fmt.Fprintln(out, "No Pod Info Extractors defined.")
+		return
+	}
+	fmt.Fprintf(out, "Pod Info Extractors:\n")
+	tbl := printer.NewTablePrinter(out)
+	tbl.SetHeader("\tNAME", "ROLE", "SELECTION POLICY", "ENV SOURCES", "VOLUME DETAILS")
+
+	for _, extractor := range *extractors {
+		role := "None"
+		if extractor.PodSelector.Role != "" {
+			role = extractor.PodSelector.Role
+		}
+		policy := fmt.Sprintf("%v", extractor.PodSelector.MultiPodSelectionPolicy)
+
+		envSources := formatEnvSources(extractor.Env)
+		volumeDetails := formatVolumeDetails(extractor.VolumeMounts)
+
+		tbl.AddRow("\t"+extractor.Name, role, policy, envSources, volumeDetails)
+	}
+	tbl.Print()
+	fmt.Fprint(out, "\n")
+}
+
+// Helper function to format environment variable sources
+func formatEnvSources(envVars []v1alpha1.OpsEnvVar) string {
+	if len(envVars) == 0 {
+		return "None"
+	}
+	var details []string
+	for _, envVar := range envVars {
+		sourceDetail := "Unknown"
+		if envVar.ValueFrom.EnvVarRef != nil {
+			sourceDetail = "EnvVar: " + envVar.ValueFrom.EnvVarRef.EnvName
+		} else if envVar.ValueFrom.FieldRef != nil {
+			sourceDetail = "FieldPath: " + envVar.ValueFrom.FieldRef.FieldPath
+		}
+		details = append(details, sourceDetail)
+	}
+	return strings.Join(details, ", ")
+}
+
+// Helper function to format volume mount details
+func formatVolumeDetails(volumeMounts []corev1.VolumeMount) string {
+	if len(volumeMounts) == 0 {
+		return "None"
+	}
+	var details []string
+	for _, vm := range volumeMounts {
+		detail := fmt.Sprintf("%s at %s", vm.Name, vm.MountPath)
+		details = append(details, detail)
+	}
+	return strings.Join(details, "; ")
+}

--- a/pkg/cmd/opsdefinition/describe.go
+++ b/pkg/cmd/opsdefinition/describe.go
@@ -106,7 +106,7 @@ func (o *describeOptions) run() error {
 
 func (o *describeOptions) describeOpsDefinition(name string) error {
 	opsDef := &v1alpha1.OpsDefinition{}
-	if err := util.GetK8SClientObject(o.dynamic, opsDef, types.OpsDefinitionGVR(), o.namespace, name); err != nil {
+	if err := util.GetK8SClientObject(o.dynamic, opsDef, types.OpsDefinitionGVR(), "", name); err != nil {
 		return fmt.Errorf("failed to get OpsDefinition '%s': %w", name, err)
 	}
 	return o.showOpsDefinition(opsDef)

--- a/pkg/cmd/opsdefinition/opsdefinition.go
+++ b/pkg/cmd/opsdefinition/opsdefinition.go
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package componentversion
+package opsdefinition
 
 import (
 	"github.com/spf13/cobra"
@@ -31,18 +31,18 @@ import (
 )
 
 var listExample = templates.Examples(`
-		# list all ComponentVersions
-		kbcli componentversion list
+		# list all ops-definitions
+		kbcli ops-definition list
 	
-		# list all ComponentVersions by alias
-		kbcli cmpv list
+		# list all ops-definitions by alias
+		kbcli ops-def list
 `)
 
-func NewComponentVersionCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+func NewOpsDefinitionCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "componentversion",
-		Short:   "ComponentVersions command.",
-		Aliases: []string{"cmpv"},
+		Use:     "ops-definition",
+		Short:   "ops-definitions command.",
+		Aliases: []string{"ops-def"},
 	}
 
 	cmd.AddCommand(NewListCmd(f, streams))
@@ -51,10 +51,10 @@ func NewComponentVersionCmd(f cmdutil.Factory, streams genericiooptions.IOStream
 }
 
 func NewListCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
-	o := action.NewListOptions(f, streams, types.ComponentVersionsGVR())
+	o := action.NewListOptions(f, streams, types.OpsDefinitionGVR())
 	cmd := &cobra.Command{
 		Use:               "list",
-		Short:             "List ComponentVersion.",
+		Short:             "List OpsDefinition.",
 		Example:           listExample,
 		Aliases:           []string{"ls"},
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, o.GVR),
@@ -64,6 +64,6 @@ func NewListCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Co
 			util.CheckErr(err)
 		},
 	}
-	o.AddFlags(cmd, true)
+	o.AddFlags(cmd, false)
 	return cmd
 }

--- a/pkg/cmd/opsdefinition/opsdefinition_test.go
+++ b/pkg/cmd/opsdefinition/opsdefinition_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package opsdefinition
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+var _ = Describe("ops-definition", func() {
+	var streams genericiooptions.IOStreams
+	var tf *cmdtesting.TestFactory
+
+	BeforeEach(func() {
+		streams, _, _, _ = genericiooptions.NewTestIOStreams()
+		tf = cmdtesting.NewTestFactory()
+	})
+
+	AfterEach(func() {
+		tf.Cleanup()
+	})
+
+	It("ops-definition cmd", func() {
+		cmd := NewOpsDefinitionCmd(tf, streams)
+		Expect(cmd).ShouldNot(BeNil())
+		Expect(cmd.HasSubCommands()).Should(BeTrue())
+	})
+
+	It("list", func() {
+		cmd := NewListCmd(tf, streams)
+		Expect(cmd).ShouldNot(BeNil())
+	})
+
+	It("describe", func() {
+		cmd := NewDescribeCmd(tf, streams)
+		Expect(cmd).ShouldNot(BeNil())
+	})
+})

--- a/pkg/cmd/opsdefinition/suite_test.go
+++ b/pkg/cmd/opsdefinition/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package opsdefinition
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOpsDefinition(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OpsDef Suite")
+}


### PR DESCRIPTION
what's changed?

support `kbcli  ops-definition/ops-def  list/ls` and `kbcli  ops-definition/ops-def  describe/desc`
<img width="898" alt="image" src="https://github.com/user-attachments/assets/3a6170d7-cf62-4371-b2a5-bf31f5d48dad">
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/6a80f51b-4ceb-4c4c-b7f5-6695ca973f45">
<img width="2197" alt="image" src="https://github.com/user-attachments/assets/f85fa659-e578-4c06-8623-3611c43e4773">
