### PR TITLE
fix: fix specifying namespace is not working

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_create_apecloud-mysql.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_apecloud-mysql.md
@@ -21,25 +21,22 @@ kbcli cluster create apecloud-mysql NAME [flags]
 ### Options
 
 ```
-      --availability-policy string     The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                      CPU cores. Value range [0.5, 64]. (default 0.5)
       --disable-exporter               Enable or disable monitor. (default true)
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
   -h, --help                           help for apecloud-mysql
-      --host-network-accessible        Specify whether the cluster can be accessed from within the VPC.
       --memory float                   Memory, the unit is Gi. Value range [0.5, 1000]. (default 0.5)
       --mode string                    Cluster topology mode. Legal values [standalone, raftGroup]. (default "standalone")
       --node-labels stringToString     Node label selector (default [])
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string       Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
       --proxy-enabled                  Enable proxy or not.
-      --publicly-accessible            Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                   Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --replicas int                   The number of replicas, for standalone mode, the replicas is 1, for raftGroup mode, the default replicas is 3. Value range [1, 5]. (default 1)
       --storage float                  Storage size, the unit is Gi. Value range [1, 10000]. (default 20)
       --storage-class-name string      Storage class name of the data volume
-      --tenancy string                 The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                 Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string      The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings            Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray      Topology keys for affinity

--- a/docs/user_docs/cli/kbcli_cluster_create_elasticsearch.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_elasticsearch.md
@@ -21,23 +21,20 @@ kbcli cluster create elasticsearch NAME [flags]
 ### Options
 
 ```
-      --availability-policy string     The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                      CPU cores. Value range [0.5, 64]. (default 1)
       --disable-exporter               Enable or disable monitor. (default true)
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
   -h, --help                           help for elasticsearch
-      --host-network-accessible        Specify whether the cluster can be accessed from within the VPC.
       --memory float                   Memory, the unit is Gi. Value range [1, 1000]. (default 2)
       --mode string                    Mode for ElasticSearch Legal values [single-node, multi-node]. (default "multi-node")
       --node-labels stringToString     Node label selector (default [])
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string       Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
-      --publicly-accessible            Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                   Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources. (default true)
       --replicas int                   The number of replicas, for single-node mode, the replicas is 1, for multi-node mode, the default replicas is 3. Value range [1, 5]. (default 1)
       --storage float                  Storage size, the unit is Gi. Value range [1, 10000]. (default 20)
-      --tenancy string                 The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                 Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string      The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings            Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray      Topology keys for affinity

--- a/docs/user_docs/cli/kbcli_cluster_create_kafka.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_kafka.md
@@ -21,7 +21,6 @@ kbcli cluster create kafka NAME [flags]
 ### Options
 
 ```
-      --availability-policy string     The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --broker-heap string             Kafka broker's jvm heap setting. (default "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64")
       --broker-replicas int            The number of Kafka broker replicas for separated mode. Value range [1, 100]. (default 1)
       --controller-heap string         Kafka controller's jvm heap setting for separated mode (default "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64")
@@ -31,7 +30,6 @@ kbcli cluster create kafka NAME [flags]
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
   -h, --help                           help for kafka
-      --host-network-accessible        Specify whether the cluster can be accessed from within the VPC.
       --memory float                   Memory, the unit is Gi. Value range [0.5, 1000]. (default 0.5)
       --meta-storage float             Metadata Storage size, the unit is Gi. Value range [1, 10000]. (default 5)
       --meta-storage-class string      The StorageClass for Kafka Metadata Storage.
@@ -42,14 +40,13 @@ kbcli cluster create kafka NAME [flags]
       --node-port-enabled              Whether NodePort service is enabled, default is false
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string       Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
-      --publicly-accessible            Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                   Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --replicas int                   The number of Kafka broker replicas for combined mode. Legal values [1, 3, 5]. (default 1)
       --sasl-enable                    Enable authentication using SASL/PLAIN for Kafka.
       --storage float                  Data Storage size, the unit is Gi. Value range [1, 10000]. (default 10)
       --storage-class string           The StorageClass for Kafka Data Storage.
       --storage-enable                 Enable storage for Kafka.
-      --tenancy string                 The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                 Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string      The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings            Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray      Topology keys for affinity

--- a/docs/user_docs/cli/kbcli_cluster_create_mongodb.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_mongodb.md
@@ -21,24 +21,21 @@ kbcli cluster create mongodb NAME [flags]
 ### Options
 
 ```
-      --availability-policy string     The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                      CPU cores. Value range [0.5, 64]. (default 0.5)
       --disable-exporter               Enable or disable monitor. (default true)
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
   -h, --help                           help for mongodb
-      --host-network-accessible        Specify whether the cluster can be accessed from within the VPC.
       --memory float                   Memory, the unit is Gi. Value range [0.5, 1000]. (default 0.5)
       --mode string                    Cluster topology mode. Legal values [standalone, replicaset]. (default "standalone")
       --node-labels stringToString     Node label selector (default [])
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string       Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
-      --publicly-accessible            Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                   Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --replicas int                   The number of replicas, for standalone mode, the replicas is 1, for replicaset mode, the default replicas is 3. Value range [1, 5]. (default 1)
       --storage float                  Storage size, the unit is Gi. Value range [1, 10000]. (default 20)
       --storage-class-name string      Storage class name of the data volume
-      --tenancy string                 The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                 Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string      The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings            Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray      Topology keys for affinity

--- a/docs/user_docs/cli/kbcli_cluster_create_mysql.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_mysql.md
@@ -21,27 +21,24 @@ kbcli cluster create mysql NAME [flags]
 ### Options
 
 ```
-      --availability-policy string     The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                      CPU cores. Value range [0.5, 64]. (default 1)
       --disable-exporter               Enable or disable monitor. (default true)
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
   -h, --help                           help for mysql
-      --host-network-accessible        Specify whether the cluster can be accessed from within the VPC.
       --memory float                   Memory, the unit is Gi. Value range [0.5, 1000]. (default 1)
       --mode string                    Cluster topology mode. Legal values [standalone, replication, raftGroup]. (default "standalone")
       --node-labels stringToString     Node label selector (default [])
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string       Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
-      --publicly-accessible            Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                   Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --replicas int                   The number of replicas. Value range [1, 5]. (default 1)
       --storage float                  Storage size, the unit is Gi. Value range [1, 10000]. (default 20)
-      --tenancy string                 The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                 Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string      The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings            Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray      Topology keys for affinity
-      --version string                 Cluster version, run "kbcli cv list --devel" to see all versions. Legal values [mysql-8.4, mysql-8.0, mysql-5.7]. (default "mysql-8.0")
+      --version string                 Cluster version, run "kbcli cv list --devel" to see all versions. Legal values [mysql-8.4, mysql-8.0, mysql-5.7, mysql-orc-8.0, mysql-orc-5.7]. (default "mysql-8.0")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_cluster_create_postgresql.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_postgresql.md
@@ -21,24 +21,21 @@ kbcli cluster create postgresql NAME [flags]
 ### Options
 
 ```
-      --availability-policy string     The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                      CPU cores. Value range [0.5, 64]. (default 0.5)
       --disable-exporter               Enable or disable monitor. (default true)
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
   -h, --help                           help for postgresql
-      --host-network-accessible        Specify whether the cluster can be accessed from within the VPC.
       --memory float                   Memory, the unit is Gi. Value range [0.5, 1000]. (default 0.5)
       --mode string                    Cluster topology mode. Legal values [standalone, replication]. (default "standalone")
       --node-labels stringToString     Node label selector (default [])
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string       Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
-      --publicly-accessible            Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                   Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --replicas int                   The number of replicas, for standalone mode, the replicas is 1, for replication mode, the default replicas is 2. Value range [1, 5]. (default 1)
       --storage float                  Storage size, the unit is Gi. Value range [1, 10000]. (default 20)
       --storage-class-name string      Storage class name of the data volume
-      --tenancy string                 The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                 Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string      The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings            Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray      Topology keys for affinity

--- a/docs/user_docs/cli/kbcli_cluster_create_qdrant.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_qdrant.md
@@ -21,23 +21,20 @@ kbcli cluster create qdrant NAME [flags]
 ### Options
 
 ```
-      --availability-policy string     The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                      CPU cores. Value range [0.5, 64]. (default 1)
       --disable-exporter               Enable or disable monitor. (default true)
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
   -h, --help                           help for qdrant
-      --host-network-accessible        Specify whether the cluster can be accessed from within the VPC.
       --memory float                   Memory, the unit is Gi. Value range [0.5, 1000]. (default 2)
       --node-labels stringToString     Node label selector (default [])
   -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string       Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
-      --publicly-accessible            Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                   Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --replicas int                   The number of replicas. Value range [1, 16]. (default 1)
       --storage float                  Storage size, the unit is Gi. Value range [1, 10000]. (default 20)
       --storage-class-name string      Storage class name of the data volume
-      --tenancy string                 The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                 Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string      The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings            Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray      Topology keys for affinity

--- a/docs/user_docs/cli/kbcli_cluster_create_redis.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_redis.md
@@ -21,20 +21,17 @@ kbcli cluster create redis NAME [flags]
 ### Options
 
 ```
-      --availability-policy string        The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                         CPU cores. Value range [0.5, 64]. (default 0.5)
       --disable-exporter                  Enable or disable monitor. (default true)
       --dry-run string[="unchanged"]      Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                              Edit the API resource before creating
   -h, --help                              help for redis
-      --host-network-accessible           Specify whether the cluster can be accessed from within the VPC.
       --memory float                      Memory, the unit is Gi. Value range [0.5, 1000]. (default 0.5)
       --mode string                       Cluster topology mode. Legal values [standalone, replication, cluster, replication-twemproxy]. (default "replication")
       --node-labels stringToString        Node label selector (default [])
       --node-port-enabled                 Whether NodePort service is enabled, default is true
   -o, --output format                     Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
       --pod-anti-affinity string          Pod anti-affinity type, one of: (Preferred, Required) (default "Preferred")
-      --publicly-accessible               Specify whether the cluster can be accessed from the public internet.
       --rbac-enabled                      Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
       --redis-cluster.shard-count float   The number of shards in the redis cluster Value range [3, 2048]. (default 3)
       --replicas int                      The number of replicas, for standalone mode, the replicas is 1, for replication mode, the default replicas is 2. Value range [1, 5]. (default 1)
@@ -45,7 +42,7 @@ kbcli cluster create redis NAME [flags]
       --sentinel.storage float            Sentinel component storage size, the unit is Gi. Value range [1, 1024]. (default 20)
       --storage float                     Storage size, the unit is Gi. Value range [1, 10000]. (default 20)
       --storage-class-name string         Storage class name of the data volume
-      --tenancy string                    The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --tenancy string                    Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")
       --termination-policy string         The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
       --tolerations strings               Tolerations for cluster, such as "key=value:effect,key:effect", for example '"engineType=mongo:NoSchedule", "diskType:NoSchedule"'
       --topology-keys stringArray         Topology keys for affinity


### PR DESCRIPTION
fix #8448

What' changed?
* only use original factory when the given factory is a test factory. 

Why?
* In other cases, the buildCustomOpsCmds() function uses a dynamic client built from the factory, which loads the kubeconfig and ignores the overriding flags like --namespace=. This results in a bug where specifying the namespace does not work as expected.