### PR TITLE
chore: fix check upgrade release status

### DIFF
--- a/pkg/cmd/kubeblocks/upgrade.go
+++ b/pkg/cmd/kubeblocks/upgrade.go
@@ -104,24 +104,12 @@ func (o *InstallOptions) getKBRelease() (*release.Release, error) {
 		}
 		o.HelmCfg.SetNamespace(ns)
 	}
-	// check helm release status
+	// get helm release
 	KBRelease, err := helm.GetHelmRelease(o.HelmCfg, types.KubeBlocksChartName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Helm release: %v in namespace %s", err, o.Namespace)
 	}
 
-	// intercept status of pending, unknown, uninstalling and uninstalled.
-	var status release.Status
-	if KBRelease != nil && KBRelease.Info != nil {
-		status = KBRelease.Info.Status
-	} else {
-		return nil, fmt.Errorf("failed to get Helm release status: release or release info is nil")
-	}
-	if status.IsPending() {
-		return nil, fmt.Errorf("helm release status is %s. Please wait until the release status changes to ‘deployed’ before upgrading KubeBlocks", status.String())
-	} else if status != release.StatusDeployed && status != release.StatusFailed && status != release.StatusSuperseded {
-		return nil, fmt.Errorf("helm release status is %s. Please fix the release before upgrading KubeBlocks", status.String())
-	}
 	return KBRelease, nil
 }
 

--- a/pkg/util/helm/errors.go
+++ b/pkg/util/helm/errors.go
@@ -33,6 +33,7 @@ import (
 // Implementing errors should be more friendly to downstream handlers
 
 var ErrReleaseNotDeployed = fmt.Errorf("release: not in deployed status")
+var ErrReleaseNotReadyForUpgrade = fmt.Errorf("release: not in deployed, failed or superseded status")
 
 func ReleaseNotFound(err error) bool {
 	if err == nil {

--- a/pkg/util/helm/helm_test.go
+++ b/pkg/util/helm/helm_test.go
@@ -132,37 +132,24 @@ var _ = Describe("helm util", func() {
 			Expect(o.Uninstall(cfg)).Should(HaveOccurred()) // release not found
 		})
 
-		It("should fail when release is not one of deployed, failed and superseded", func() {
-			err := actionCfg.Releases.Create(&release.Release{
-				Name:    o.Name,
-				Version: 1,
-				Info: &release.Info{
-					Status: release.StatusDeployed,
-				},
-				Chart: &chart.Chart{},
-			})
-			Expect(err).Should(BeNil())
-			_, err = o.tryUpgrade(actionCfg)
-			Expect(err).Should(HaveOccurred())                // failed at fetching charts
-			Expect(o.tryUninstall(actionCfg)).Should(BeNil()) // release exists
-		})
-
-		testCase := []struct {
-			status      release.Status
-			checkResult bool
-		}{
-			{release.StatusDeployed, true},
-			{release.StatusSuperseded, true},
-			{release.StatusFailed, true},
-			{release.StatusUnknown, false},
-			{release.StatusUninstalled, false},
-			{release.StatusUninstalling, false},
-			{release.StatusPendingInstall, false},
-			{release.StatusPendingUpgrade, false},
-			{release.StatusPendingRollback, false},
-		}
-
 		It("should fail when status is not one of deployed, failed and superseded.", func() {
+			testCase := []struct {
+				status      release.Status
+				checkResult bool
+			}{
+				// deployed, failed and superseded
+				{release.StatusDeployed, true},
+				{release.StatusSuperseded, true},
+				{release.StatusFailed, true},
+				// others
+				{release.StatusUnknown, false},
+				{release.StatusUninstalled, false},
+				{release.StatusUninstalling, false},
+				{release.StatusPendingInstall, false},
+				{release.StatusPendingUpgrade, false},
+				{release.StatusPendingRollback, false},
+			}
+
 			for i := range testCase {
 				err := actionCfg.Releases.Create(&release.Release{
 					Name:    o.Name,


### PR DESCRIPTION
move checking upgrade release status from kubeblocks/upgrade() to helm/upgrade() and improve UT.