### PR TITLE
chore: cluster stop and start support components

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_custom-ops.md
+++ b/docs/user_docs/cli/kbcli_cluster_custom-ops.md
@@ -57,11 +57,6 @@ kbcli cluster custom-ops OpsDef --cluster <clusterName> <your custom params> [fl
 ### SEE ALSO
 
 * [kbcli cluster](kbcli_cluster.md)	 - Cluster command.
-* [kbcli cluster custom-ops etcd-defragmentation](kbcli_cluster_custom-ops_etcd-defragmentation.md)	 - Create a custom ops with opsDef etcd-defragmentation
-* [kbcli cluster custom-ops kafka-quota](kbcli_cluster_custom-ops_kafka-quota.md)	 - Create a custom ops with opsDef kafka-quota
-* [kbcli cluster custom-ops kafka-topic](kbcli_cluster_custom-ops_kafka-topic.md)	 - Create a custom ops with opsDef kafka-topic
-* [kbcli cluster custom-ops kafka-user-acl](kbcli_cluster_custom-ops_kafka-user-acl.md)	 - Create a custom ops with opsDef kafka-user-acl
-* [kbcli cluster custom-ops mysql-orc-switchover](kbcli_cluster_custom-ops_mysql-orc-switchover.md)	 - Create a custom ops with opsDef mysql-orc-switchover
 
 #### Go Back to [CLI Overview](cli.md) Homepage.
 

--- a/docs/user_docs/cli/kbcli_cluster_start.md
+++ b/docs/user_docs/cli/kbcli_cluster_start.md
@@ -13,11 +13,15 @@ kbcli cluster start NAME [flags]
 ```
   # start the cluster when cluster is stopped
   kbcli cluster start mycluster
+  
+  # start the component of the cluster when cluster is stopped
+  kbcli cluster start mycluster --components=mysql
 ```
 
 ### Options
 
 ```
+      --components strings             Component names to this operations
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
       --force                           skip the pre-checks of the opsRequest to run the opsRequest forcibly

--- a/docs/user_docs/cli/kbcli_cluster_stop.md
+++ b/docs/user_docs/cli/kbcli_cluster_stop.md
@@ -13,12 +13,16 @@ kbcli cluster stop NAME [flags]
 ```
   # stop the cluster and release all the pods of the cluster
   kbcli cluster stop mycluster
+  
+  # stop the component of the cluster and release all the pods of the component
+  kbcli cluster stop mycluster --components=mysql
 ```
 
 ### Options
 
 ```
       --auto-approve                   Skip interactive approval before stopping the cluster
+      --components strings             Component names to this operations
       --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
       --edit                           Edit the API resource before creating
       --force                           skip the pre-checks of the opsRequest to run the opsRequest forcibly

--- a/pkg/action/template/cluster_operations_template.cue
+++ b/pkg/action/template/cluster_operations_template.cue
@@ -123,10 +123,14 @@ content: {
 		ttlSecondsAfterSucceed: options.ttlSecondsAfterSucceed
 		force:                  options.force
 		if options.type == "Stop" {
-			stop: options.componentNames
+			stop: [ for _, cName in options.componentNames {
+				componentName: cName
+			}]
 		}
 		if options.type == "Start" {
-			start: options.componentNames
+			start: [ for _, cName in options.componentNames {
+				componentName: cName
+			}]
 		}
 		if options.type == "Upgrade" {
 			upgrade: #upgrade

--- a/pkg/action/template/cluster_operations_template.cue
+++ b/pkg/action/template/cluster_operations_template.cue
@@ -122,6 +122,12 @@ content: {
 		type:                   options.type
 		ttlSecondsAfterSucceed: options.ttlSecondsAfterSucceed
 		force:                  options.force
+		if options.type == "Stop" {
+			stop: options.componentNames
+		}
+		if options.type == "Start" {
+			start: options.componentNames
+		}
 		if options.type == "Upgrade" {
 			upgrade: #upgrade
 		}

--- a/pkg/cmd/cluster/register.go
+++ b/pkg/cmd/cluster/register.go
@@ -241,5 +241,5 @@ Use "kbcli cluster create {{ .ClusterType }}" to create a {{ .ClusterType }} clu
 	_ = util.PrintGoTemplate(&builder, exampleTpl, map[string]interface{}{
 		"ClusterType": t.String(),
 	})
-	return templates.Examples(builder.String())
+	return templates.Examples(builder.String()) + "\n"
 }


### PR DESCRIPTION
cluster stop and start support components.

Change flags of these two commands, and modify the .cue file to render the opsRequest.