### PR TITLE
chore: playground init support specifying k3s and k3d-proxy images.

### DIFF
--- a/docs/user_docs/cli/kbcli_playground_init.md
+++ b/docs/user_docs/cli/kbcli_playground_init.md
@@ -43,13 +43,15 @@ kbcli playground init [flags]
 ### Options
 
 ```
-      --auto-approve            Skip interactive approval during the initialization of playground
-      --cloud-provider string   Cloud provider type, one of [local aws] (default "local")
-      --cluster-type string     Specify the cluster type to create, use 'kbcli cluster create --help' to get the available cluster type. (default "apecloud-mysql")
-  -h, --help                    help for init
-      --region string           The region to create kubernetes cluster
-      --timeout duration        Time to wait for init playground, such as --timeout=10m (default 10m0s)
-      --version string          KubeBlocks version
+      --auto-approve             Skip interactive approval during the initialization of playground
+      --cloud-provider string    Cloud provider type, one of [local aws] (default "local")
+      --cluster-type string      Specify the cluster type to create, use 'kbcli cluster create --help' to get the available cluster type. (default "apecloud-mysql")
+  -h, --help                     help for init
+      --k3d-proxy-image string   Specify k3d proxy image if you want to init playground locally (default "docker.io/apecloud/k3d-proxy:5.4.4")
+      --k3s-image string         Specify k3s image that you want to use for the nodes if you want to init playground locally (default "rancher/k3s:v1.23.8-k3s1")
+      --region string            The region to create kubernetes cluster
+      --timeout duration         Time to wait for init playground, such as --timeout=10m (default 10m0s)
+      --version string           KubeBlocks version
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cloudprovider/k3d_test.go
+++ b/pkg/cloudprovider/k3d_test.go
@@ -31,13 +31,30 @@ var _ = Describe("playground", func() {
 	var (
 		provider    = newLocalCloudProvider(os.Stdout, os.Stderr)
 		clusterName = "k3d-kb-test"
+		image       = "test.com/k3d-proxy:5.4.4"
 	)
 
-	It("k3d util function", func() {
-		config, err := buildClusterRunConfig("test")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(config.Name).Should(ContainSubstring("test"))
-		Expect(setUpK3d(context.Background(), nil)).Should(HaveOccurred())
-		Expect(provider.DeleteK8sCluster(&K8sClusterInfo{ClusterName: clusterName})).Should(HaveOccurred())
+	Context("k3d util function", func() {
+		It("with name", func() {
+			config, err := buildClusterRunConfig("test", "", "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(config.Name).Should(ContainSubstring("test"))
+			Expect(setUpK3d(context.Background(), nil)).Should(HaveOccurred())
+			Expect(provider.DeleteK8sCluster(&K8sClusterInfo{ClusterName: clusterName})).Should(HaveOccurred())
+		})
+
+		It("with name and k3s image", func() {
+			config, err := buildClusterRunConfig("test", image, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(config.Cluster.Nodes[1].Image).Should(ContainSubstring("test.com"))
+		})
+
+		It("with name and k3d proxy image", func() {
+			config, err := buildClusterRunConfig("test", "", image)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(config.ServerLoadBalancer.Node.Image).Should(ContainSubstring("test.com"))
+		})
+
 	})
+
 })

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -33,6 +33,6 @@ func TestPlayground(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// set fake image info
-	K3sImage = "fake-k3s-image"
-	K3dProxyImage = "fake-k3d-proxy-image"
+	K3sImageDefault = "fake-k3s-image"
+	K3dProxyImageDefault = "fake-k3d-proxy-image"
 })

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -68,6 +68,13 @@ type K8sClusterInfo struct {
 	Region        string `json:"region,omitempty"`
 	KubeConfig    string `json:"kube_config,omitempty"`
 	KbcliVersion  string `json:"kbcli_version,omitempty"`
+	K3dClusterInfo
+}
+
+// K3dClusterInfo is the k3d cluster information for playground
+type K3dClusterInfo struct {
+	K3sImage      string `json:"k3s_image,omitempty"`
+	K3dProxyImage string `json:"k3d_proxy_image,omitempty"`
 }
 
 // IsValid checks if kubernetes cluster info is valid

--- a/pkg/cmd/cluster/operations.go
+++ b/pkg/cmd/cluster/operations.go
@@ -1096,14 +1096,9 @@ func getTempFactory(f cmdutil.Factory) cmdutil.Factory {
 func buildCustomOpsCmds(option *OperationsOptions) []*cobra.Command {
 	dynamic, _ := getTempFactory(option.Factory).DynamicClient()
 	if dynamic == nil {
-		println("Failed to list OpsDefinitions")
 		return nil
 	}
-	opsDefs, err := dynamic.Resource(types.OpsDefinitionGVR()).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		println("Failed to list OpsDefinitions: %v", err)
-		return nil
-	}
+	opsDefs, _ := dynamic.Resource(types.OpsDefinitionGVR()).List(context.TODO(), metav1.ListOptions{})
 	if opsDefs == nil {
 		return nil
 	}

--- a/pkg/cmd/cluster/operations.go
+++ b/pkg/cmd/cluster/operations.go
@@ -1095,7 +1095,15 @@ func getTempFactory(f cmdutil.Factory) cmdutil.Factory {
 
 func buildCustomOpsCmds(option *OperationsOptions) []*cobra.Command {
 	dynamic, _ := getTempFactory(option.Factory).DynamicClient()
-	opsDefs, _ := dynamic.Resource(types.OpsDefinitionGVR()).List(context.TODO(), metav1.ListOptions{})
+	if dynamic == nil {
+		println("Failed to list OpsDefinitions")
+		return nil
+	}
+	opsDefs, err := dynamic.Resource(types.OpsDefinitionGVR()).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		println("Failed to list OpsDefinitions: %v", err)
+		return nil
+	}
 	if opsDefs == nil {
 		return nil
 	}

--- a/pkg/cmd/cluster/register_test.go
+++ b/pkg/cmd/cluster/register_test.go
@@ -98,7 +98,7 @@ var _ = Describe("cluster register", func() {
 		)
 
 		AfterEach(func() {
-			cluster.ClearCharts(cluster.ClusterType(engine))
+			os.Remove(filepath.Join(cluster.CliChartsCacheDir, filepath.Base(source)))
 		})
 
 		It("test register chart by source", func() {

--- a/pkg/cmd/playground/init.go
+++ b/pkg/cmd/playground/init.go
@@ -96,6 +96,8 @@ type initOptions struct {
 	region        string
 	autoApprove   bool
 	dockerVersion *gv.Version
+	k3sImage      string
+	k3dProxyImage string
 
 	baseOptions
 }
@@ -123,6 +125,8 @@ func newInitCmd(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&o.region, "region", "", "The region to create kubernetes cluster")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 600*time.Second, "Time to wait for init playground, such as --timeout=10m")
 	cmd.Flags().BoolVar(&o.autoApprove, "auto-approve", false, "Skip interactive approval during the initialization of playground")
+	cmd.Flags().StringVar(&o.k3sImage, "k3s-image", cp.K3sImageDefault, "Specify k3s image that you want to use for the nodes if you want to init playground locally")
+	cmd.Flags().StringVar(&o.k3dProxyImage, "k3d-proxy-image", cp.K3dProxyImageDefault, "Specify k3d proxy image if you want to init playground locally")
 
 	util.CheckErr(cmd.RegisterFlagCompletionFunc(
 		"cloud-provider",
@@ -192,6 +196,10 @@ func (o *initOptions) local() error {
 		clusterInfo = &cp.K8sClusterInfo{
 			CloudProvider: provider.Name(),
 			ClusterName:   types.K3dClusterName,
+			K3dClusterInfo: cp.K3dClusterInfo{
+				K3sImage:      o.k3sImage,
+				K3dProxyImage: o.k3dProxyImage,
+			},
 		}
 	}
 

--- a/pkg/cmd/playground/init.go
+++ b/pkg/cmd/playground/init.go
@@ -96,10 +96,14 @@ type initOptions struct {
 	region        string
 	autoApprove   bool
 	dockerVersion *gv.Version
+
+	k3dClusterOptions
+	baseOptions
+}
+
+type k3dClusterOptions struct {
 	k3sImage      string
 	k3dProxyImage string
-
-	baseOptions
 }
 
 func newInitCmd(streams genericiooptions.IOStreams) *cobra.Command {

--- a/pkg/cmd/playground/suite_test.go
+++ b/pkg/cmd/playground/suite_test.go
@@ -37,8 +37,8 @@ func TestPlayground(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// set fake image info
-	cp.K3sImage = "fake-k3s-image"
-	cp.K3dProxyImage = "fake-k3d-proxy-image"
+	cp.K3sImageDefault = "fake-k3s-image"
+	cp.K3dProxyImageDefault = "fake-k3d-proxy-image"
 
 	// set default cluster name to test
 	types.K3dClusterName = "kb-playground-test"


### PR DESCRIPTION
fix #488

* `playground init `support specifying k3s and k3d-proxy images by two flags `--k3s-image` and `--k3d-proxy-image`.  
* For example, you can use `kbcli playground init --k3d-proxy-image=registry.aliyuncs.com/apecloud/k3d-proxy:5.4.4` to specify the image of k3d-proxy. 
* fix a bug of remaining test file after running ut in cmd/cluster.