### PR TITLE
chore: remove standard schema

### DIFF
--- a/pkg/cluster/external_charts.go
+++ b/pkg/cluster/external_charts.go
@@ -21,7 +21,6 @@ package cluster
 
 import (
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -29,6 +28,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"k8s.io/klog"
@@ -246,15 +246,6 @@ func (h *TypeInstance) PatchNewClusterType() error {
 	return GlobalClusterChartConfig.WriteConfigs(CliClusterChartConfig)
 }
 
-var StandardSchema = map[string]interface{}{
-	"properties": map[string]interface{}{
-		"replicas": nil,
-		"cpu":      nil,
-		"memory":   nil,
-		"storage":  nil,
-	},
-}
-
 func (h *TypeInstance) ValidateChartSchema() (bool, error) {
 	file, err := h.loadChart()
 	if err != nil {
@@ -266,41 +257,31 @@ func (h *TypeInstance) ValidateChartSchema() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	data := c.Schema
-	if len(data) == 0 {
+	if c.Schema == nil || len(c.Schema) == 0 {
 		return false, fmt.Errorf("register cluster chart of %s failed, schema of the chart doesn't exist", h.Name)
 	}
-
-	var schema map[string]interface{}
-	if err := json.Unmarshal(data, &schema); err != nil {
-		return false, fmt.Errorf("register cluster chart of %s failed, error decoding JSON: %s", h.Name, err)
+	if c.Values == nil {
+		return false, fmt.Errorf("register cluster chart of %s failed, values of the chart doesn't exist", h.Name)
 	}
 
-	if err := validateSchema(schema, StandardSchema); err != nil {
-		return false, err
+	schemaLoader := gojsonschema.NewStringLoader(string(c.Schema))
+	valuesLoader := gojsonschema.NewGoLoader(c.Values)
+
+	result, err := gojsonschema.Validate(schemaLoader, valuesLoader)
+	if err != nil {
+		return false, fmt.Errorf("Validation failed: %s\n", err)
 	}
 
-	return true, nil
-}
-
-func validateSchema(schema, standard map[string]interface{}) error {
-	for key, val := range standard {
-		if subStandard, ok := val.(map[string]interface{}); ok {
-			subSchema, ok := schema[key].(map[string]interface{})
-			if !ok {
-				return fmt.Errorf("register cluster chart failed, schema missing required map key '%s'", key)
-			}
-			if err := validateSchema(subSchema, subStandard); err != nil {
-				return err
-			}
-		} else {
-			if _, exists := schema[key]; !exists {
-				return fmt.Errorf("register cluster chart failed, schema missing required key '%s'", key)
-			}
+	if result.Valid() {
+		return true, nil
+	} else {
+		fmt.Println("Values do not match the schema:")
+		res := ""
+		for _, desc := range result.Errors() {
+			res += fmt.Sprintf("- %s\n", desc)
 		}
+		return false, fmt.Errorf(res)
 	}
-	return nil
 }
 
 var _ chartLoader = &TypeInstance{}


### PR DESCRIPTION

* Remove standard schema check during chart registering.
* Check if `values.yaml` and `values.schema.json` exist, and valid the values by its schema.