### PR TITLE
fix: improve typo of list cmd in dataprotection

### DIFF
--- a/docs/user_docs/cli/cli.md
+++ b/docs/user_docs/cli/cli.md
@@ -123,11 +123,11 @@ Data protection command.
 * [kbcli dataprotection describe-backup-policy](kbcli_dataprotection_describe-backup-policy.md)	 - Describe a backup policy
 * [kbcli dataprotection describe-restore](kbcli_dataprotection_describe-restore.md)	 - Describe a restore
 * [kbcli dataprotection edit-backup-policy](kbcli_dataprotection_edit-backup-policy.md)	 - Edit backup policy
-* [kbcli dataprotection list-action-set](kbcli_dataprotection_list-action-set.md)	 - List actionsets
-* [kbcli dataprotection list-backup](kbcli_dataprotection_list-backup.md)	 - List backups.
-* [kbcli dataprotection list-backup-policy](kbcli_dataprotection_list-backup-policy.md)	 - List backup policies
-* [kbcli dataprotection list-backup-policy-template](kbcli_dataprotection_list-backup-policy-template.md)	 - List backup policy template
-* [kbcli dataprotection list-restore](kbcli_dataprotection_list-restore.md)	 - List restores.
+* [kbcli dataprotection list-action-sets](kbcli_dataprotection_list-action-sets.md)	 - List actionsets
+* [kbcli dataprotection list-backup-policies](kbcli_dataprotection_list-backup-policies.md)	 - List backup policies
+* [kbcli dataprotection list-backup-policy-templates](kbcli_dataprotection_list-backup-policy-templates.md)	 - List backup policy templates
+* [kbcli dataprotection list-backups](kbcli_dataprotection_list-backups.md)	 - List backups.
+* [kbcli dataprotection list-restores](kbcli_dataprotection_list-restores.md)	 - List restores.
 * [kbcli dataprotection restore](kbcli_dataprotection_restore.md)	 - Restore a new cluster from backup
 
 

--- a/docs/user_docs/cli/kbcli_dataprotection.md
+++ b/docs/user_docs/cli/kbcli_dataprotection.md
@@ -43,11 +43,11 @@ Data protection command.
 * [kbcli dataprotection describe-backup-policy](kbcli_dataprotection_describe-backup-policy.md)	 - Describe a backup policy
 * [kbcli dataprotection describe-restore](kbcli_dataprotection_describe-restore.md)	 - Describe a restore
 * [kbcli dataprotection edit-backup-policy](kbcli_dataprotection_edit-backup-policy.md)	 - Edit backup policy
-* [kbcli dataprotection list-action-set](kbcli_dataprotection_list-action-set.md)	 - List actionsets
-* [kbcli dataprotection list-backup](kbcli_dataprotection_list-backup.md)	 - List backups.
-* [kbcli dataprotection list-backup-policy](kbcli_dataprotection_list-backup-policy.md)	 - List backup policies
-* [kbcli dataprotection list-backup-policy-template](kbcli_dataprotection_list-backup-policy-template.md)	 - List backup policy template
-* [kbcli dataprotection list-restore](kbcli_dataprotection_list-restore.md)	 - List restores.
+* [kbcli dataprotection list-action-sets](kbcli_dataprotection_list-action-sets.md)	 - List actionsets
+* [kbcli dataprotection list-backup-policies](kbcli_dataprotection_list-backup-policies.md)	 - List backup policies
+* [kbcli dataprotection list-backup-policy-templates](kbcli_dataprotection_list-backup-policy-templates.md)	 - List backup policy templates
+* [kbcli dataprotection list-backups](kbcli_dataprotection_list-backups.md)	 - List backups.
+* [kbcli dataprotection list-restores](kbcli_dataprotection_list-restores.md)	 - List restores.
 * [kbcli dataprotection restore](kbcli_dataprotection_restore.md)	 - Restore a new cluster from backup
 
 #### Go Back to [CLI Overview](cli.md) Homepage.

--- a/docs/user_docs/cli/kbcli_dataprotection_backup.md
+++ b/docs/user_docs/cli/kbcli_dataprotection_backup.md
@@ -17,7 +17,7 @@ kbcli dataprotection backup NAME [flags]
   # create a backup with a specified method, run "kbcli cluster desc-backup-policy mycluster" to show supported backup methods
   kbcli dp backup mybackup --cluster mycluster --method mymethod
   
-  # create a backup with specified backup policy, run "kbcli cluster list-backup-policy mycluster" to show the cluster supported backup policies
+  # create a backup with specified backup policy, run "kbcli cluster list-backup-policies mycluster" to show the cluster supported backup policies
   kbcli dp backup mybackup --cluster mycluster --policy mypolicy
   
   # create a backup from a parent backup

--- a/docs/user_docs/cli/kbcli_dataprotection_list-backups.md
+++ b/docs/user_docs/cli/kbcli_dataprotection_list-backups.md
@@ -21,11 +21,13 @@ kbcli dataprotection list-backups [flags]
 ### Options
 
 ```
-      --cluster string    List backups in the specified cluster
-  -h, --help              help for list-backups
-  -o, --output format     prints the output in the specified format. Allowed values: table, json, yaml, wide (default table)
-  -l, --selector string   Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.
-      --show-labels       When printing, show all labels as the last column (default hide labels column)
+  -A, --all-namespaces     If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+      --cluster string     List backups in the specified cluster
+  -h, --help               help for list-backups
+  -n, --namespace string   specified the namespace
+  -o, --output format      prints the output in the specified format. Allowed values: table, json, yaml, wide (default table)
+  -l, --selector string    Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.
+      --show-labels        When printing, show all labels as the last column (default hide labels column)
 ```
 
 ### Options inherited from parent commands
@@ -43,7 +45,6 @@ kbcli dataprotection list-backups [flags]
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
       --match-server-version           Require server version to match client version
-  -n, --namespace string               If present, the namespace scope for this CLI request
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used

--- a/pkg/cmd/dataprotection/actionset.go
+++ b/pkg/cmd/dataprotection/actionset.go
@@ -43,7 +43,7 @@ func newListActionSetCmd(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	o := action.NewListOptions(f, streams, types.ActionSetGVR())
 	headers := []any{"NAME", "BACKUP-TYPE", "STATUS", "CREATED-TIME"}
 	cmd := &cobra.Command{
-		Use:               "list-action-set",
+		Use:               "list-action-sets",
 		Short:             "List actionsets",
 		Aliases:           []string{"list-as"},
 		Example:           listActionSetExample,

--- a/pkg/cmd/dataprotection/backup.go
+++ b/pkg/cmd/dataprotection/backup.go
@@ -247,7 +247,7 @@ func newBackupCommand(f cmdutil.Factory, streams genericiooptions.IOStreams) *co
 	customOutPut := func(opt *action.CreateOptions) {
 		output := fmt.Sprintf("Backup %s created successfully, you can view the progress:", opt.Name)
 		printer.PrintLine(output)
-		nextLine := fmt.Sprintf("\tkbcli dp list-backup %s -n %s", opt.Name, opt.Namespace)
+		nextLine := fmt.Sprintf("\tkbcli dp list-backups %s -n %s", opt.Name, opt.Namespace)
 		printer.PrintLine(nextLine)
 	}
 

--- a/pkg/cmd/dataprotection/backup.go
+++ b/pkg/cmd/dataprotection/backup.go
@@ -55,7 +55,7 @@ var (
 		# create a backup with a specified method, run "kbcli cluster desc-backup-policy mycluster" to show supported backup methods
 		kbcli dp backup mybackup --cluster mycluster --method mymethod
 
-		# create a backup with specified backup policy, run "kbcli cluster list-backup-policy mycluster" to show the cluster supported backup policies
+		# create a backup with specified backup policy, run "kbcli cluster list-backup-policies mycluster" to show the cluster supported backup policies
 		kbcli dp backup mybackup --cluster mycluster --policy mypolicy
 
 		# create a backup from a parent backup
@@ -74,10 +74,10 @@ var (
 
 	listBackupExample = templates.Examples(`
 		# list all backups
-		kbcli dp list-backup
+		kbcli dp list-backups
 
 		# list all backups of specified cluster
-		kbcli dp list-backup --cluster mycluster
+		kbcli dp list-backups --cluster mycluster
 	`)
 )
 
@@ -375,7 +375,7 @@ func newListBackupCommand(f cmdutil.Factory, streams genericiooptions.IOStreams)
 	o := action.NewListOptions(f, streams, types.BackupGVR())
 	clusterName := ""
 	cmd := &cobra.Command{
-		Use:               "list-backup",
+		Use:               "list-backups",
 		Short:             "List backups.",
 		Aliases:           []string{"ls-backups"},
 		Example:           listBackupExample,

--- a/pkg/cmd/dataprotection/backuppolicy.go
+++ b/pkg/cmd/dataprotection/backuppolicy.go
@@ -50,7 +50,7 @@ import (
 var (
 	listBackupPolicyExample = templates.Examples(`
 		# list all backup policies
-		kbcli dp list-backup-policy
+		kbcli dp list-backup-policies
 
 		# using short cmd to list backup policy of the specified cluster
         kbcli dp list-bp mycluster
@@ -143,7 +143,7 @@ func newListBackupPolicyCmd(f cmdutil.Factory, streams genericclioptions.IOStrea
 	o := action.NewListOptions(f, streams, types.BackupPolicyGVR())
 	clusterName := ""
 	cmd := &cobra.Command{
-		Use:               "list-backup-policy",
+		Use:               "list-backup-policies",
 		Short:             "List backup policies",
 		Aliases:           []string{"list-bp"},
 		Example:           listBackupPolicyExample,

--- a/pkg/cmd/dataprotection/backuppolicytemplate.go
+++ b/pkg/cmd/dataprotection/backuppolicytemplate.go
@@ -43,8 +43,8 @@ func newListBackupPolicyTemplateCmd(f cmdutil.Factory, streams genericclioptions
 	o := action.NewListOptions(f, streams, types.BackupPolicyTemplateGVR())
 	headers := []any{"NAME", "SERVICE-KIND", "STATUS", "CREATED-TIME"}
 	cmd := &cobra.Command{
-		Use:               "list-backup-policy-template",
-		Short:             "List backup policy template",
+		Use:               "list-backup-policy-templates",
+		Short:             "List backup policy templates",
 		Aliases:           []string{"list-bpt"},
 		Example:           listBPTExample,
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, o.GVR),

--- a/pkg/cmd/dataprotection/datatprotection_test.go
+++ b/pkg/cmd/dataprotection/datatprotection_test.go
@@ -100,7 +100,7 @@ var _ = Describe("DataProtection", func() {
 			tf.FakeDynamicClient = testing.FakeDynamicClient(objects...)
 		}
 
-		It("list-action-set", func() {
+		It("list-action-sets", func() {
 			By("fake client")
 			initClient()
 
@@ -124,7 +124,7 @@ var _ = Describe("DataProtection", func() {
 			Expect(len(strings.Split(strings.Trim(out.String(), "\n"), "\n"))).Should(Equal(2))
 		})
 
-		It("list-backup-policy", func() {
+		It("list-backup-policies", func() {
 			By("fake client")
 			defaultBackupPolicy := testing.FakeBackupPolicy(policyName, testing.ClusterName)
 			policy2 := testing.FakeBackupPolicy("policy1", testing.ClusterName)
@@ -132,7 +132,7 @@ var _ = Describe("DataProtection", func() {
 			policy3.Namespace = "policy"
 			initClient(defaultBackupPolicy, policy2, policy3)
 
-			By("test list-backup-policy cmd")
+			By("test list-backup-policies cmd")
 			cmd := newListBackupPolicyCmd(tf, streams)
 			Expect(cmd).ShouldNot(BeNil())
 			cmd.Run(cmd, nil)
@@ -261,16 +261,16 @@ var _ = Describe("DataProtection", func() {
 			Expect(completeForDeleteBackup(o, "")).Should(HaveOccurred())
 		})
 
-		It("list-backup", func() {
+		It("list-backups", func() {
 			cmd := newListBackupCommand(tf, streams)
 			Expect(cmd).ShouldNot(BeNil())
-			By("test list-backup cmd with no backup")
+			By("test list-backups cmd with no backup")
 			tf.FakeDynamicClient = testing.FakeDynamicClient()
 			o := action.NewListOptions(tf, streams, types.BackupGVR())
 			Expect(PrintBackupList(o)).Should(Succeed())
 			Expect(o.ErrOut.(*bytes.Buffer).String()).Should(ContainSubstring("No backups found"))
 
-			By("test list-backup")
+			By("test list-backups")
 			backup1 := testing.FakeBackup("test1")
 			backup1.Labels = map[string]string{
 				constant.AppInstanceLabelKey: "apecloud-mysql",
@@ -338,7 +338,7 @@ var _ = Describe("DataProtection", func() {
 			Expect(capturedOutput).Should(ContainSubstring(testing.BackupName))
 		})
 
-		It("list-restore", func() {
+		It("list-restores", func() {
 			By("fake client")
 			initClient(testing.FakeRestore(testing.BackupName))
 

--- a/pkg/cmd/dataprotection/restore.go
+++ b/pkg/cmd/dataprotection/restore.go
@@ -54,7 +54,7 @@ var (
 
 	listRestoreExample = templates.Examples(`
 		# list all restores
-		kbcli dp list-restore`)
+		kbcli dp list-restores`)
 )
 
 type CreateRestoreOptions struct {
@@ -155,7 +155,7 @@ func newListRestoreCommand(f cmdutil.Factory, streams genericiooptions.IOStreams
 	o := action.NewListOptions(f, streams, types.RestoreGVR())
 	clusterName := ""
 	cmd := &cobra.Command{
-		Use:               "list-restore",
+		Use:               "list-restores",
 		Short:             "List restores.",
 		Aliases:           []string{"ls-restores"},
 		Example:           listRestoreExample,


### PR DESCRIPTION
fix #510
list-backup --> list-backups
list-action-set --> list-action-sets
list-backup-policy --> list-backup-policies
list-backup-policy-template --> list-backup-policy-templates
list-restore --> list-restores