### PR TITLE
feat: improve cluster list

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_list.md
+++ b/docs/user_docs/cli/kbcli_cluster_list.md
@@ -36,6 +36,7 @@ kbcli cluster list [NAME] [flags]
   -o, --output format      prints the output in the specified format. Allowed values: table, json, yaml, wide (default table)
   -l, --selector string    Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.
       --show-labels        When printing, show all labels as the last column (default hide labels column)
+      --status string      Filter objects by given status.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -67,6 +67,7 @@ type ListOptions struct {
 	// only return the result to caller.
 	Print  bool
 	SortBy string
+	Status string
 	genericiooptions.IOStreams
 }
 

--- a/pkg/cluster/printer.go
+++ b/pkg/cluster/printer.go
@@ -166,7 +166,7 @@ func (p *Printer) filterByStatus() {
 
 // sortRows Sort By namespace(1), clusterDef(2), status(4), name(0)
 func (p *Printer) sortRows() {
-	// for PrintClusters 和 PrintWide
+	// for PrintClusters and PrintWide
 	// NAME(0), NAMESPACE(1), CLUSTER-DEFINITION(2), STATUS(4)
 	sort.Slice(p.rows, func(i, j int) bool {
 		ri, rj := p.rows[i], p.rows[j]

--- a/pkg/cmd/cluster/list.go
+++ b/pkg/cmd/cluster/list.go
@@ -93,6 +93,7 @@ func NewListCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Co
 		},
 	}
 	o.AddFlags(cmd)
+	cmd.Flags().StringVar(&o.Status, "status", "", "Filter objects by given status.")
 	return cmd
 }
 
@@ -151,7 +152,7 @@ func NewListEventsCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *co
 }
 
 func run(o *action.ListOptions, printType cluster.PrintType) error {
-	// if format is JSON or YAML, use default printer to output the result.
+	// if format is JSON or YAML, use default printer.
 	if o.Format == printer.JSON || o.Format == printer.YAML {
 		_, err := o.Run()
 		return err
@@ -185,7 +186,8 @@ func run(o *action.ListOptions, printType cluster.PrintType) error {
 	}
 
 	opt := &cluster.PrinterOptions{
-		ShowLabels: o.ShowLabels,
+		ShowLabels:   o.ShowLabels,
+		StatusFilter: o.Status,
 	}
 
 	p := cluster.NewPrinter(o.IOStreams.Out, printType, opt)

--- a/pkg/cmd/cluster/list_test.go
+++ b/pkg/cmd/cluster/list_test.go
@@ -21,14 +21,19 @@ package cluster
 
 import (
 	"bytes"
+	"github.com/spf13/cobra"
 	"net/http"
 	"strings"
 
+	"github.com/apecloud/kbcli/pkg/testing"
+	"github.com/apecloud/kbcli/pkg/types"
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -36,21 +41,9 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientfake "k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-
-	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-
-	"github.com/apecloud/kbcli/pkg/cluster"
-	"github.com/apecloud/kbcli/pkg/testing"
-	"github.com/apecloud/kbcli/pkg/types"
 )
 
 var _ = Describe("list", func() {
-	var (
-		streams genericiooptions.IOStreams
-		out     *bytes.Buffer
-		tf      *cmdtesting.TestFactory
-	)
-
 	const (
 		namespace             = "test"
 		clusterName           = "test"
@@ -59,13 +52,32 @@ var _ = Describe("list", func() {
 		verticalScalingReason = "VerticalScaling"
 	)
 
+	var (
+		streams genericiooptions.IOStreams
+		out     *bytes.Buffer
+		tf      *cmdtesting.TestFactory
+	)
+
+	// httpResp returns a *http.Response for the given runtime.Object.
+	httpResp := func(codec runtime.Codec, obj runtime.Object) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     cmdtesting.DefaultHeader(),
+			Body:       cmdtesting.ObjBody(codec, obj),
+		}
+	}
+
 	BeforeEach(func() {
 		streams, _, out, _ = genericiooptions.NewTestIOStreams()
 		tf = testing.NewTestFactory(namespace)
 
-		_ = kbappsv1.AddToScheme(scheme.Scheme)
+		// Prepare schemes
+		Expect(kbappsv1.AddToScheme(scheme.Scheme)).Should(Succeed())
 		codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-		cluster := testing.FakeCluster(clusterName, namespace, metav1.Condition{
+
+		By("Creating test clusters and pods")
+		// Prepare test data
+		baseCluster := testing.FakeCluster(clusterName, namespace, metav1.Condition{
 			Type:   appsv1alpha1.ConditionTypeApplyResources,
 			Status: metav1.ConditionFalse,
 			Reason: "HorizontalScaleFailed",
@@ -76,91 +88,194 @@ var _ = Describe("list", func() {
 			Reason: verticalScalingReason,
 		})
 		clusterWithVerticalScaling.Status.Phase = kbappsv1.UpdatingClusterPhase
+
 		clusterWithAbnormalPhase := testing.FakeCluster(clusterName2, namespace)
 		clusterWithAbnormalPhase.Status.Phase = kbappsv1.AbnormalClusterPhase
-		pods := testing.FakePods(3, namespace, clusterName)
-		httpResp := func(obj runtime.Object) *http.Response {
-			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, obj)}
-		}
 
+		pods := testing.FakePods(3, namespace, clusterName)
+
+		By("Configuring the fake REST client responses")
 		tf.UnstructuredClient = &clientfake.RESTClient{
 			GroupVersion:         schema.GroupVersion{Group: types.AppsAPIGroup, Version: types.AppsAPIVersion},
 			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 			Client: clientfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				urlPrefix := "/api/v1/namespaces/" + namespace
-				return map[string]*http.Response{
-					"/namespaces/" + namespace + "/clusters":                 httpResp(&kbappsv1.ClusterList{Items: []kbappsv1.Cluster{*cluster}}),
-					"/namespaces/" + namespace + "/clusters/" + clusterName:  httpResp(cluster),
-					"/namespaces/" + namespace + "/clusters/" + clusterName1: httpResp(clusterWithVerticalScaling),
-					"/namespaces/" + namespace + "/clusters/" + clusterName2: httpResp(clusterWithAbnormalPhase),
-					"/namespaces/" + namespace + "/secrets":                  httpResp(testing.FakeSecrets(namespace, clusterName)),
-					"/api/v1/nodes/" + testing.NodeName:                      httpResp(testing.FakeNode()),
-					urlPrefix + "/services":                                  httpResp(&corev1.ServiceList{}),
-					urlPrefix + "/secrets":                                   httpResp(testing.FakeSecrets(namespace, clusterName)),
-					urlPrefix + "/pods":                                      httpResp(pods),
-					urlPrefix + "/events":                                    httpResp(testing.FakeEvents()),
-				}[req.URL.Path], nil
+				pathToResponse := map[string]*http.Response{
+					"/namespaces/" + namespace + "/clusters":                 httpResp(codec, &kbappsv1.ClusterList{Items: []kbappsv1.Cluster{*baseCluster}}),
+					"/namespaces/" + namespace + "/clusters/" + clusterName:  httpResp(codec, baseCluster),
+					"/namespaces/" + namespace + "/clusters/" + clusterName1: httpResp(codec, clusterWithVerticalScaling),
+					"/namespaces/" + namespace + "/clusters/" + clusterName2: httpResp(codec, clusterWithAbnormalPhase),
+					"/namespaces/" + namespace + "/secrets":                  httpResp(codec, testing.FakeSecrets(namespace, clusterName)),
+					"/api/v1/nodes/" + testing.NodeName:                      httpResp(codec, testing.FakeNode()),
+					urlPrefix + "/services":                                  httpResp(codec, &corev1.ServiceList{}),
+					urlPrefix + "/secrets":                                   httpResp(codec, testing.FakeSecrets(namespace, clusterName)),
+					urlPrefix + "/pods":                                      httpResp(codec, pods),
+					urlPrefix + "/events":                                    httpResp(codec, testing.FakeEvents()),
+				}
+				return pathToResponse[req.URL.Path], nil
 			}),
 		}
 
 		tf.Client = tf.UnstructuredClient
-		tf.FakeDynamicClient = testing.FakeDynamicClient(cluster, clusterWithVerticalScaling, clusterWithAbnormalPhase, testing.FakeClusterDef())
+		tf.FakeDynamicClient = testing.FakeDynamicClient(
+			baseCluster,
+			clusterWithVerticalScaling,
+			clusterWithAbnormalPhase,
+			testing.FakeClusterDef(),
+		)
 	})
 
 	AfterEach(func() {
+		By("Cleaning up the test factory")
 		tf.Cleanup()
 	})
 
-	It("list", func() {
-		cmd := NewListCmd(tf, streams)
-		Expect(cmd).ShouldNot(BeNil())
+	// Helper to run command and return output
+	runCmd := func(cmd *cobra.Command, args ...string) string {
+		out.Reset()
+		cmd.Run(cmd, args)
+		return out.String()
+	}
 
-		cmd.Run(cmd, []string{clusterName, clusterName1, clusterName2})
-		Expect(out.String()).Should(ContainSubstring(clusterName))
-		Expect(out.String()).Should(ContainSubstring(string(appsv1alpha1.UpdatingClusterPhase)))
-		Expect(out.String()).Should(ContainSubstring(cluster.ConditionsError))
-		Expect(out.String()).Should(ContainSubstring(string(appsv1alpha1.AbnormalClusterPhase)))
+	It("list clusters by name", func() {
+		By("Running list command with cluster names")
+		cmd := NewListCmd(tf, streams)
+		output := runCmd(cmd, clusterName, clusterName1, clusterName2)
+
+		By("Checking output for expected clusters and statuses")
+		Expect(output).Should(ContainSubstring(clusterName))
+		Expect(output).Should(ContainSubstring(string(appsv1alpha1.UpdatingClusterPhase)))
+		Expect(output).Should(ContainSubstring("HorizontalScaleFailed"))
+		Expect(output).Should(ContainSubstring(string(appsv1alpha1.AbnormalClusterPhase)))
 	})
 
-	It("list instances", func() {
+	It("list instances for a specific cluster", func() {
+		By("Running list-instances command for a given cluster")
 		cmd := NewListInstancesCmd(tf, streams)
-		Expect(cmd).ShouldNot(BeNil())
+		output := runCmd(cmd, clusterName)
 
-		cmd.Run(cmd, []string{clusterName})
-		Expect(out.String()).Should(ContainSubstring(testing.NodeName))
+		By("Checking output for expected node name in instances list")
+		Expect(output).Should(ContainSubstring(testing.NodeName))
 	})
 
-	It("list components", func() {
+	It("list components for a specific cluster", func() {
+		By("Running list-components command for a given cluster")
 		cmd := NewListComponentsCmd(tf, streams)
-		Expect(cmd).ShouldNot(BeNil())
+		output := runCmd(cmd, clusterName)
 
-		cmd.Run(cmd, []string{clusterName})
-		Expect(out.String()).Should(ContainSubstring(testing.ComponentName))
+		By("Checking output for expected component name")
+		Expect(output).Should(ContainSubstring(testing.ComponentName))
 	})
 
-	It("list events", func() {
+	It("list events for a specific cluster", func() {
+		By("Running list-events command for a given cluster")
 		cmd := NewListEventsCmd(tf, streams)
-		Expect(cmd).ShouldNot(BeNil())
+		output := runCmd(cmd, clusterName)
 
-		cmd.Run(cmd, []string{clusterName})
-		Expect(len(strings.Split(out.String(), "\n")) > 1).Should(BeTrue())
+		By("Verifying that multiple events are returned")
+		Expect(len(strings.Split(strings.TrimSpace(output), "\n")) > 1).Should(BeTrue())
 	})
 
-	It("output wide", func() {
+	It("output wide with cluster name", func() {
+		By("Setting output format to wide")
 		cmd := NewListCmd(tf, streams)
-		Expect(cmd).ShouldNot(BeNil())
-
 		Expect(cmd.Flags().Set("output", "wide")).Should(Succeed())
-		cmd.Run(cmd, []string{clusterName})
-		Expect(out.String()).Should(ContainSubstring(clusterName))
+
+		By("Running the command with a specific cluster")
+		output := runCmd(cmd, clusterName)
+		Expect(output).Should(ContainSubstring(clusterName))
 	})
 
-	It("output wide without args", func() {
+	It("output wide without specifying cluster names", func() {
+		By("Setting output format to wide without arguments")
 		cmd := NewListCmd(tf, streams)
-		Expect(cmd).ShouldNot(BeNil())
-
 		Expect(cmd.Flags().Set("output", "wide")).Should(Succeed())
-		cmd.Run(cmd, []string{})
-		Expect(out.String()).Should(ContainSubstring(clusterName))
+
+		output := runCmd(cmd)
+		Expect(output).Should(ContainSubstring(clusterName))
+	})
+
+	It("should list clusters sorted and filtered by status", func() {
+		By("Preparing multiple clusters for sorting and filtering test")
+		clusterA := testing.FakeCluster("clusterA", "ns1", metav1.Condition{
+			Type:   appsv1alpha1.ConditionTypeReady,
+			Status: metav1.ConditionTrue,
+			Reason: "Ready",
+		})
+		clusterA.Status.Phase = kbappsv1.RunningClusterPhase
+		clusterA.Spec.ClusterDef = "cd-mysql"
+
+		clusterB := testing.FakeCluster("clusterB", "ns1", metav1.Condition{
+			Type:   appsv1alpha1.ConditionTypeReady,
+			Status: metav1.ConditionTrue,
+			Reason: "Ready",
+		})
+		clusterB.Status.Phase = kbappsv1.CreatingClusterPhase
+		clusterB.Spec.ClusterDef = "cd-mysql"
+
+		clusterC := testing.FakeCluster("clusterC", "ns2", metav1.Condition{
+			Type:   appsv1alpha1.ConditionTypeReady,
+			Status: metav1.ConditionFalse,
+			Reason: "Scaling",
+		})
+		clusterC.Status.Phase = kbappsv1.UpdatingClusterPhase
+		clusterC.Spec.ClusterDef = "cd-postgres"
+
+		codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+		tf.UnstructuredClient = &clientfake.RESTClient{
+			GroupVersion:         schema.GroupVersion{Group: types.AppsAPIGroup, Version: types.AppsAPIVersion},
+			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+
+			Client: clientfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				pathToResponse := map[string]*http.Response{
+					"/namespaces/" + namespace + "/clusters": httpResp(codec, &kbappsv1.ClusterList{
+						Items: []kbappsv1.Cluster{*clusterA, *clusterB, *clusterC},
+					}),
+				}
+				return pathToResponse[req.URL.Path], nil
+			}),
+		}
+
+		tf.Client = tf.UnstructuredClient
+
+		tf.FakeDynamicClient = testing.FakeDynamicClient(clusterA, clusterB, clusterC, testing.FakeClusterDef())
+
+		By("Listing all clusters across all namespaces")
+		cmd := NewListCmd(tf, streams)
+		output := runCmd(cmd)
+
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		Expect(lines).To(ContainElements(
+			ContainSubstring("clusterB"), // Creating
+			ContainSubstring("clusterA"), // Running
+			ContainSubstring("clusterC"), // Updating
+		))
+
+		// Extract indices for validation
+		var bIndex, aIndex, cIndex int
+		for i, line := range lines {
+			switch {
+			case strings.Contains(line, "clusterB"):
+				bIndex = i
+			case strings.Contains(line, "clusterA"):
+				aIndex = i
+			case strings.Contains(line, "clusterC"):
+				cIndex = i
+			}
+		}
+
+		Expect(bIndex).To(BeNumerically("<", aIndex)) // Creating < Running
+		Expect(aIndex).To(BeNumerically("<", cIndex)) // Running < Updating
+
+		By("Filtering clusters by status Running")
+		out.Reset()
+		cmd = NewListCmd(tf, streams)
+		Expect(cmd.Flags().Set("status", "Running")).Should(Succeed())
+		output = runCmd(cmd)
+
+		// Only clusterA should remain (Running)
+		Expect(output).To(ContainSubstring("clusterA"))
+		Expect(output).NotTo(ContainSubstring("clusterB"))
+		Expect(output).NotTo(ContainSubstring("clusterC"))
 	})
 })

--- a/pkg/cmd/cluster/list_test.go
+++ b/pkg/cmd/cluster/list_test.go
@@ -21,19 +21,14 @@ package cluster
 
 import (
 	"bytes"
-	"github.com/spf13/cobra"
 	"net/http"
 	"strings"
 
-	"github.com/apecloud/kbcli/pkg/testing"
-	"github.com/apecloud/kbcli/pkg/types"
-	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
-	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -41,6 +36,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientfake "k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+
+	"github.com/apecloud/kbcli/pkg/cluster"
+	"github.com/apecloud/kbcli/pkg/testing"
+	"github.com/apecloud/kbcli/pkg/types"
 )
 
 var _ = Describe("list", func() {
@@ -145,7 +147,7 @@ var _ = Describe("list", func() {
 		By("Checking output for expected clusters and statuses")
 		Expect(output).Should(ContainSubstring(clusterName))
 		Expect(output).Should(ContainSubstring(string(appsv1alpha1.UpdatingClusterPhase)))
-		Expect(output).Should(ContainSubstring("HorizontalScaleFailed"))
+		Expect(output).Should(ContainSubstring(cluster.ConditionsError))
 		Expect(output).Should(ContainSubstring(string(appsv1alpha1.AbnormalClusterPhase)))
 	})
 


### PR DESCRIPTION
fix #448

what's changed?

1. improve order of cluster list, now the sort order is namespace、clusterDefinition、 status、 name.
2. add a flag of cluster list to specify the status to filter.

usage:
`kbcli cluster list --status=Running`