### PR TITLE
chore: addon install and search support auto complete

### DIFF
--- a/docs/user_docs/cli/kbcli_addon_search.md
+++ b/docs/user_docs/cli/kbcli_addon_search.md
@@ -5,7 +5,7 @@ title: kbcli addon search
 Search the addon from index
 
 ```
-kbcli addon search [flags]
+kbcli addon search [ADDON_NAME] [flags]
 ```
 
 ### Examples

--- a/pkg/cmd/addon/install.go
+++ b/pkg/cmd/addon/install.go
@@ -131,6 +131,7 @@ func newInstallCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			util.CheckErr(addDefaultIndex())
 		},
+		ValidArgsFunction: addonNameCompletionFunc,
 		Run: func(cmd *cobra.Command, args []string) {
 			o.name = args[0]
 			util.CheckErr(o.Complete())

--- a/pkg/cmd/addon/util.go
+++ b/pkg/cmd/addon/util.go
@@ -136,7 +136,7 @@ func checkAddonInstalled(objects *[]searchResult, o *addonListOpts) error {
 
 func CheckAddonUsedByCluster(dynamic dynamic.Interface, addons []string, in io.Reader) error {
 	labelSelecotor := util.BuildClusterLabel("", addons)
-	list, err := dynamic.Resource(types.ClusterGVR()).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelecotor})
+	list, err := dynamic.Resource(types.ClusterGVR()).Namespace(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelecotor})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/addon/util.go
+++ b/pkg/cmd/addon/util.go
@@ -23,14 +23,20 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
 
 	"github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
@@ -150,4 +156,85 @@ func CheckAddonUsedByCluster(dynamic dynamic.Interface, addons []string, in io.R
 		return prompt.Confirm(maps.Keys(usedAddons), in, msg, "")
 	}
 	return nil
+}
+
+// addonNameCompletionFunc provides name auto-completion for addons
+func addonNameCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	fmt.Printf("toComplete: %s\n", toComplete)
+	var addonDir string
+	var err error
+	addonDir, err = util.GetCliAddonDir()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Retrieve all addon names
+	allAddons, err := getAllAddonNames(addonDir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	matches := fuzzyMatch(allAddons, toComplete)
+	return matches, cobra.ShellCompDirectiveNoFileComp
+}
+
+// getAllAddonNames retrieves all addon names from the given directory
+func getAllAddonNames(dir string) ([]string, error) {
+	var addonNames []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Skip hidden directories
+		if strings.HasPrefix(d.Name(), ".") && d.IsDir() {
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(strings.ToLower(d.Name()), ".yaml") {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				klog.V(2).Infof("read file %s error: %v", path, err)
+				return nil
+			}
+			addon := &extensionsv1alpha1.Addon{}
+			if yaml.Unmarshal(content, addon) != nil {
+				return nil
+			}
+			if addon.Kind == "Addon" && addon.Name != "" {
+				addonNames = append(addonNames, addon.Name)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove duplicates
+	nameSet := make(map[string]struct{})
+	for _, n := range addonNames {
+		nameSet[n] = struct{}{}
+	}
+	var unique []string
+	for n := range nameSet {
+		unique = append(unique, n)
+	}
+	return unique, nil
+}
+
+// fuzzyMatch performs simple substring fuzzy matching on names
+func fuzzyMatch(names []string, prefix string) []string {
+	if prefix == "" {
+		return names
+	}
+	var matches []string
+	lp := strings.ToLower(prefix)
+	for _, n := range names {
+		if strings.Contains(strings.ToLower(n), lp) {
+			matches = append(matches, n)
+		}
+	}
+	return matches
 }

--- a/pkg/cmd/addon/util_test.go
+++ b/pkg/cmd/addon/util_test.go
@@ -24,7 +24,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -48,12 +47,6 @@ var _ = Describe("addon util test", func() {
 	const (
 		fakeAddonName = testing.ClusterDefName
 		namespace     = testing.Namespace
-		addon1Content = `kind: Addon
-name: addon1`
-		addon2Content = `kind: Addon
-name: addon2`
-		invalidContent = `kind: Invalid
-name: invalid-addon`
 	)
 
 	mockClient := func(data runtime.Object) *cmdtesting.TestFactory {
@@ -77,14 +70,5 @@ name: invalid-addon`
 	})
 	It("text CheckAddonUsedByCluster", func() {
 		Expect(CheckAddonUsedByCluster(tf.FakeDynamicClient, []string{fakeAddonName}, streams.In)).Should(HaveOccurred())
-	})
-	It("should return matched addon names for prefix 'my'", func() {
-		// Verify the function
-		toComplete := "my"
-		names, directive := addonNameCompletionFunc(nil, nil, toComplete)
-
-		// Validate results
-		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
-		Expect(len(names)).ShouldNot(Equal(0))
 	})
 })

--- a/pkg/cmd/addon/util_test.go
+++ b/pkg/cmd/addon/util_test.go
@@ -20,11 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package addon
 
 import (
-	"net/http"
-
+	"github.com/apecloud/kbcli/pkg/testing"
+	"github.com/apecloud/kbcli/pkg/types"
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -32,9 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientfake "k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-
-	"github.com/apecloud/kbcli/pkg/testing"
-	"github.com/apecloud/kbcli/pkg/types"
+	"net/http"
 )
 
 var _ = Describe("addon util test", func() {
@@ -46,6 +45,12 @@ var _ = Describe("addon util test", func() {
 	const (
 		fakeAddonName = testing.ClusterDefName
 		namespace     = testing.Namespace
+		addon1Content = `kind: Addon
+name: addon1`
+		addon2Content = `kind: Addon
+name: addon2`
+		invalidContent = `kind: Invalid
+name: invalid-addon`
 	)
 
 	mockClient := func(data runtime.Object) *cmdtesting.TestFactory {
@@ -70,5 +75,13 @@ var _ = Describe("addon util test", func() {
 	It("text CheckAddonUsedByCluster", func() {
 		Expect(CheckAddonUsedByCluster(tf.FakeDynamicClient, []string{fakeAddonName}, streams.In)).Should(HaveOccurred())
 	})
+	It("should return matched addon names for prefix 'my'", func() {
+		// Verify the function
+		toComplete := "my"
+		names, directive := addonNameCompletionFunc(nil, nil, toComplete)
 
+		// Validate results
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+		Expect(len(names)).ShouldNot(Equal(0))
+	})
 })

--- a/pkg/cmd/addon/util_test.go
+++ b/pkg/cmd/addon/util_test.go
@@ -20,9 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package addon
 
 import (
-	"github.com/apecloud/kbcli/pkg/testing"
-	"github.com/apecloud/kbcli/pkg/types"
-	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"net/http"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
@@ -33,7 +32,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientfake "k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-	"net/http"
+
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+
+	"github.com/apecloud/kbcli/pkg/testing"
+	"github.com/apecloud/kbcli/pkg/types"
 )
 
 var _ = Describe("addon util test", func() {


### PR DESCRIPTION
fix #517

`kbcli addon install` and `kbcli addon search` support auto complete the name of addon. All names of addon are read from the index diractory.
