### PR TITLE
[codex] Upgrade KubeBlocks dependency to v1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/NimbleMarkets/ntcharts v0.1.2
 	github.com/apecloud/dbctl v0.0.0-20240827084000-68a1980b1a46
-	github.com/apecloud/kubeblocks v1.1.0-beta.5
+	github.com/apecloud/kubeblocks v1.2.0-alpha.2
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/briandowns/spinner v1.23.0
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230912020346-a5d89c1c90ad
@@ -71,7 +71,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/component-base v0.33.3
 	k8s.io/klog v1.0.0
-	k8s.io/klog/v2 v2.130.1
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
 	k8s.io/kubectl v0.33.3
 	k8s.io/metrics v0.29.14

--- a/go.sum
+++ b/go.sum
@@ -697,6 +697,8 @@ github.com/apecloud/dbctl v0.0.0-20240827084000-68a1980b1a46 h1:+Jcc7IjDGxPgIfIk
 github.com/apecloud/dbctl v0.0.0-20240827084000-68a1980b1a46/go.mod h1:eksJtZ7z1nVcVLqDzAdcN5EfpHwXllIAvHZEks2zWys=
 github.com/apecloud/kubeblocks v1.1.0-beta.5 h1:a3Jng19OOquH12SqqEBi/pd6fMAeD01NCInLZe9nTP4=
 github.com/apecloud/kubeblocks v1.1.0-beta.5/go.mod h1:vx9p2tv5x4NZiShUvl1MXVl9RO343Bu1nCpbAKdcA6k=
+github.com/apecloud/kubeblocks v1.2.0-alpha.2 h1:dHfjbAc8u59TPbi7Rrqqn7PdgglI7ihryXNnR04Oh2A=
+github.com/apecloud/kubeblocks v1.2.0-alpha.2/go.mod h1:w00VNDQqlqrjz4GGCE48hvJjAKfdzx83V7mkZAxJPIg=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -2685,6 +2687,8 @@ k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
+k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUyGcf03XZEP0ZIKgKj35LS4=
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=

--- a/pkg/cmd/cluster/config_edit.go
+++ b/pkg/cmd/cluster/config_edit.go
@@ -29,7 +29,6 @@ import (
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	configctrl "github.com/apecloud/kubeblocks/pkg/parameters"
-	cfgcm "github.com/apecloud/kubeblocks/pkg/parameters/configmanager"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 	"github.com/apecloud/kubeblocks/pkg/parameters/validate"
 	"github.com/spf13/cobra"
@@ -111,7 +110,7 @@ func hasSchemaForFile(rctx *ReconfigureContext, configFile string) bool {
 	if rctx.ConfigRender == nil {
 		return false
 	}
-	return configctrl.GetComponentConfigDescription(&rctx.ConfigRender.Spec, configFile) != nil
+	return configctrl.GetComponentConfigDescription(configDescriptions(rctx), configFile) != nil
 }
 
 func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditContext, rctx *ReconfigureContext, fn func() error) error {
@@ -122,7 +121,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 		o.CfgFile: cfgEditContext.getEdited(),
 	}
 
-	configPatch, fileUpdated, err := core.CreateConfigPatch(oldVersion, newVersion, rctx.ConfigRender.Spec, true)
+	configPatch, fileUpdated, err := core.CreateConfigPatch(oldVersion, newVersion, configDescriptions(rctx), true)
 	if err != nil {
 		return err
 	}
@@ -133,7 +132,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 
 	fmt.Fprintf(o.CreateOptions.Out, "Config patch(updated parameters): \n%s\n\n", string(configPatch.UpdateConfig[o.CfgFile]))
 	if !o.enableDelete {
-		if err := core.ValidateConfigPatch(configPatch, rctx.ConfigRender.Spec); err != nil {
+		if err := core.ValidateConfigPatch(configPatch, configDescriptions(rctx)); err != nil {
 			return err
 		}
 	}
@@ -146,7 +145,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 	}
 
 	var config *parametersv1alpha1.ComponentConfigDescription
-	if config = configctrl.GetComponentConfigDescription(&rctx.ConfigRender.Spec, o.CfgFile); config == nil {
+	if config = configctrl.GetComponentConfigDescription(configDescriptions(rctx), o.CfgFile); config == nil {
 		return fn()
 	}
 	var pd *parametersv1alpha1.ParametersDefinition
@@ -188,7 +187,7 @@ func generateReconfiguringPrompt(fileUpdated bool, configPatch *core.ConfigPatch
 	}
 
 	confirmPrompt := confirmApplyReconfigurePrompt
-	if !dynamicUpdated || !cfgcm.IsSupportReload(pd.Spec.ReloadAction) {
+	if !dynamicUpdated || !supportsDynamicReload(&pd.Spec) {
 		confirmPrompt = restartConfirmPrompt
 	}
 	return confirmPrompt, nil

--- a/pkg/cmd/cluster/config_observer.go
+++ b/pkg/cmd/cluster/config_observer.go
@@ -140,7 +140,7 @@ func (r *configObserverOptions) printComponentConfigSpecsDescribe(rctx *Reconfig
 func (r *configObserverOptions) printComponentExplainConfigure(rctx *ReconfigureContext) error {
 	for _, pd := range rctx.ParametersDefs {
 		if rctx.ConfigRender != nil {
-			config := configctrl.GetComponentConfigDescription(&rctx.ConfigRender.Spec, pd.Spec.FileName)
+			config := configctrl.GetComponentConfigDescription(configDescriptions(rctx), pd.Spec.FileName)
 			if config != nil {
 				fmt.Println("template meta:")
 				printer.PrintLineWithTabSeparator(

--- a/pkg/cmd/cluster/config_ops.go
+++ b/pkg/cmd/cluster/config_ops.go
@@ -29,7 +29,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/client/clientset/versioned"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	configctrl "github.com/apecloud/kubeblocks/pkg/parameters"
-	cfgcm "github.com/apecloud/kubeblocks/pkg/parameters/configmanager"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -137,7 +136,7 @@ func (o *configOpsOptions) Validate() error {
 		return err
 	}
 
-	classifyParams, err := configctrl.ClassifyComponentParameters(o.KeyValues, rctx.ParametersDefs, rctx.Cmpd.Spec.Configs, tplObjs, rctx.ConfigRender)
+	classifyParams, err := configctrl.ClassifyComponentParameters(o.KeyValues, rctx.ParametersDefs, rctx.Cmpd.Spec.Configs, tplObjs, configDescriptions(rctx))
 	if err != nil {
 		return err
 	}
@@ -161,7 +160,7 @@ func (o *configOpsOptions) validateConfigParams(rctx *ReconfigureContext, classi
 	checkRestart := func(params map[string]*parametersv1alpha1.ParametersInFile) bool {
 		for file := range params {
 			match := func(pd *parametersv1alpha1.ParametersDefinition) bool {
-				return pd.Spec.FileName == file && cfgcm.IsSupportReload(pd.Spec.ReloadAction)
+				return pd.Spec.FileName == file && supportsDynamicReload(&pd.Spec)
 			}
 			if generics.FindFirstFunc(rctx.ParametersDefs, match) < 0 {
 				return true
@@ -173,7 +172,7 @@ func (o *configOpsOptions) validateConfigParams(rctx *ReconfigureContext, classi
 	transform := func(params map[string]*parametersv1alpha1.ParametersInFile) []core.ParamPairs {
 		var result []core.ParamPairs
 		for file, ps := range params {
-			configDescs := configctrl.GetComponentConfigDescriptions(&rctx.ConfigRender.Spec, file)
+			configDescs := configctrl.GetComponentConfigDescriptions(configDescriptions(rctx), file)
 			builder := configctrl.NewValueManager(rctx.ParametersDefs, configDescs)
 			updatedParams, _ := core.FromStringMap(ps.Parameters, builder.BuildValueTransformer(file))
 			result = append(result, core.ParamPairs{
@@ -186,7 +185,7 @@ func (o *configOpsOptions) validateConfigParams(rctx *ReconfigureContext, classi
 
 	restart := false
 	for _, parameters := range classifyParameters {
-		_, err := configctrl.MergeAndValidateConfigs(mockEmptyData(parameters), transform(parameters), rctx.ParametersDefs, rctx.ConfigRender.Spec.Configs)
+		_, err := configctrl.MergeAndValidateConfigs(mockEmptyData(parameters), transform(parameters), rctx.ParametersDefs, configDescriptions(rctx))
 		if err != nil {
 			return err
 		}
@@ -207,6 +206,16 @@ func mockEmptyData(m map[string]*parametersv1alpha1.ParametersInFile) map[string
 		r[key] = ""
 	}
 	return r
+}
+
+func supportsDynamicReload(pd *parametersv1alpha1.ParametersDefinitionSpec) bool {
+	if pd == nil {
+		return false
+	}
+	if configctrl.NeedDynamicReloadAction(pd) {
+		return true
+	}
+	return pd.ReloadAction != nil && (pd.ReloadAction.AutoTrigger != nil || pd.ReloadAction.ShellTrigger != nil)
 }
 
 func fromStringPointerMap(m map[string]string) map[string]*string {

--- a/pkg/cmd/cluster/config_ops_test.go
+++ b/pkg/cmd/cluster/config_ops_test.go
@@ -33,6 +33,7 @@ import (
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	kbfakeclient "github.com/apecloud/kubeblocks/pkg/client/clientset/versioned/fake"
 	cfgcore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -118,6 +119,21 @@ var _ = Describe("reconfigure test", func() {
 
 		o.CreateOptions.In = io.NopCloser(in)
 		Expect(o.Validate()).Should(Succeed())
+	})
+
+	It("detects v1.2 and legacy dynamic reload support", func() {
+		mergeReloadAndRestart := false
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{
+			MergeReloadAndRestart: &mergeReloadAndRestart,
+		})).Should(BeTrue())
+
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{
+			ReloadAction: &parametersv1alpha1.ReloadAction{
+				ShellTrigger: &parametersv1alpha1.ShellTrigger{},
+			},
+		})).Should(BeTrue())
+
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{})).Should(BeFalse())
 	})
 
 })

--- a/pkg/cmd/cluster/config_wrapper.go
+++ b/pkg/cmd/cluster/config_wrapper.go
@@ -61,7 +61,7 @@ func (w *ReconfigureWrapper) ConfigSpecName() string {
 	}
 	file := w.ConfigFile()
 	if file != "" && w.rctx.ConfigRender != nil {
-		config := configctrl.GetComponentConfigDescription(&w.rctx.ConfigRender.Spec, file)
+		config := configctrl.GetComponentConfigDescription(configDescriptions(w.rctx), file)
 		if config != nil {
 			return config.TemplateName
 		}
@@ -81,6 +81,13 @@ func (w *ReconfigureWrapper) ConfigFile() string {
 		return w.rctx.ConfigRender.Spec.Configs[0].Name
 	}
 	return ""
+}
+
+func configDescriptions(rctx *ReconfigureContext) []parametersv1alpha1.ComponentConfigDescription {
+	if rctx == nil || rctx.ConfigRender == nil {
+		return nil
+	}
+	return rctx.ConfigRender.Spec.Configs
 }
 
 func GetClientFromOptionsOrDie(factory cmdutil.Factory) versioned.Interface {


### PR DESCRIPTION
## Summary
- upgrade github.com/apecloud/kubeblocks to v1.2.0-alpha.2
- adapt cluster config/reconfigure code to the v1.2 parameters API
- preserve legacy reload-action handling while supporting v1.2 dynamic reload metadata

## Root cause
KubeBlocks v1.2 changed Cluster config fields such as configs[].reconfigure to booleans and removed the old pkg/parameters/configmanager package. kbcli needed to consume the new API shape and replace the removed helper usage.