### PR TITLE
fix: reconfig error Upgrade KubeBlocks dependency to v1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/NimbleMarkets/ntcharts v0.1.2
 	github.com/apecloud/dbctl v0.0.0-20240827084000-68a1980b1a46
-	github.com/apecloud/kubeblocks v1.1.0-beta.5
+	github.com/apecloud/kubeblocks v1.2.0-alpha.2
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/briandowns/spinner v1.23.0
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230912020346-a5d89c1c90ad
@@ -71,7 +71,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/component-base v0.33.3
 	k8s.io/klog v1.0.0
-	k8s.io/klog/v2 v2.130.1
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff
 	k8s.io/kubectl v0.33.3
 	k8s.io/metrics v0.29.14

--- a/go.sum
+++ b/go.sum
@@ -697,6 +697,8 @@ github.com/apecloud/dbctl v0.0.0-20240827084000-68a1980b1a46 h1:+Jcc7IjDGxPgIfIk
 github.com/apecloud/dbctl v0.0.0-20240827084000-68a1980b1a46/go.mod h1:eksJtZ7z1nVcVLqDzAdcN5EfpHwXllIAvHZEks2zWys=
 github.com/apecloud/kubeblocks v1.1.0-beta.5 h1:a3Jng19OOquH12SqqEBi/pd6fMAeD01NCInLZe9nTP4=
 github.com/apecloud/kubeblocks v1.1.0-beta.5/go.mod h1:vx9p2tv5x4NZiShUvl1MXVl9RO343Bu1nCpbAKdcA6k=
+github.com/apecloud/kubeblocks v1.2.0-alpha.2 h1:dHfjbAc8u59TPbi7Rrqqn7PdgglI7ihryXNnR04Oh2A=
+github.com/apecloud/kubeblocks v1.2.0-alpha.2/go.mod h1:w00VNDQqlqrjz4GGCE48hvJjAKfdzx83V7mkZAxJPIg=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -2685,6 +2687,8 @@ k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
+k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUyGcf03XZEP0ZIKgKj35LS4=
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=

--- a/pkg/cmd/cluster/config_edit.go
+++ b/pkg/cmd/cluster/config_edit.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strings"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	configctrl "github.com/apecloud/kubeblocks/pkg/parameters"
@@ -156,7 +157,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 		}
 	}
 
-	confirmPrompt, err := generateReconfiguringPrompt(fileUpdated, configPatch, pd, o.CfgFile, config.FileFormatConfig)
+	confirmPrompt, err := generateReconfiguringPrompt(fileUpdated, configPatch, pd, o.CfgFile, config.FileFormatConfig, componentFileTemplate(rctx, config.TemplateName))
 	if err != nil {
 		return err
 	}
@@ -176,7 +177,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 	return fn()
 }
 
-func generateReconfiguringPrompt(fileUpdated bool, configPatch *core.ConfigPatchInfo, pd *parametersv1alpha1.ParametersDefinition, fileName string, config *parametersv1alpha1.FileFormatConfig) (string, error) {
+func generateReconfiguringPrompt(fileUpdated bool, configPatch *core.ConfigPatchInfo, pd *parametersv1alpha1.ParametersDefinition, fileName string, config *parametersv1alpha1.FileFormatConfig, template *kbappsv1.ComponentFileTemplate) (string, error) {
 	if fileUpdated || pd == nil {
 		return restartConfirmPrompt, nil
 	}
@@ -187,7 +188,7 @@ func generateReconfiguringPrompt(fileUpdated bool, configPatch *core.ConfigPatch
 	}
 
 	confirmPrompt := confirmApplyReconfigurePrompt
-	if !dynamicUpdated || !supportsDynamicReload(&pd.Spec) {
+	if !dynamicUpdated || !supportsDynamicReload(&pd.Spec, template) {
 		confirmPrompt = restartConfirmPrompt
 	}
 	return confirmPrompt, nil

--- a/pkg/cmd/cluster/config_edit.go
+++ b/pkg/cmd/cluster/config_edit.go
@@ -29,7 +29,6 @@ import (
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	configctrl "github.com/apecloud/kubeblocks/pkg/parameters"
-	cfgcm "github.com/apecloud/kubeblocks/pkg/parameters/configmanager"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 	"github.com/apecloud/kubeblocks/pkg/parameters/validate"
 	"github.com/spf13/cobra"
@@ -111,7 +110,7 @@ func hasSchemaForFile(rctx *ReconfigureContext, configFile string) bool {
 	if rctx.ConfigRender == nil {
 		return false
 	}
-	return configctrl.GetComponentConfigDescription(&rctx.ConfigRender.Spec, configFile) != nil
+	return configctrl.GetComponentConfigDescription(configDescriptions(rctx), configFile) != nil
 }
 
 func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditContext, rctx *ReconfigureContext, fn func() error) error {
@@ -122,7 +121,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 		o.CfgFile: cfgEditContext.getEdited(),
 	}
 
-	configPatch, fileUpdated, err := core.CreateConfigPatch(oldVersion, newVersion, rctx.ConfigRender.Spec, true)
+	configPatch, fileUpdated, err := core.CreateConfigPatch(oldVersion, newVersion, configDescriptions(rctx), true)
 	if err != nil {
 		return err
 	}
@@ -133,7 +132,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 
 	fmt.Fprintf(o.CreateOptions.Out, "Config patch(updated parameters): \n%s\n\n", string(configPatch.UpdateConfig[o.CfgFile]))
 	if !o.enableDelete {
-		if err := core.ValidateConfigPatch(configPatch, rctx.ConfigRender.Spec); err != nil {
+		if err := core.ValidateConfigPatch(configPatch, configDescriptions(rctx)); err != nil {
 			return err
 		}
 	}
@@ -146,7 +145,7 @@ func (o *editConfigOptions) runWithConfigConstraints(cfgEditContext *configEditC
 	}
 
 	var config *parametersv1alpha1.ComponentConfigDescription
-	if config = configctrl.GetComponentConfigDescription(&rctx.ConfigRender.Spec, o.CfgFile); config == nil {
+	if config = configctrl.GetComponentConfigDescription(configDescriptions(rctx), o.CfgFile); config == nil {
 		return fn()
 	}
 	var pd *parametersv1alpha1.ParametersDefinition
@@ -188,7 +187,7 @@ func generateReconfiguringPrompt(fileUpdated bool, configPatch *core.ConfigPatch
 	}
 
 	confirmPrompt := confirmApplyReconfigurePrompt
-	if !dynamicUpdated || !cfgcm.IsSupportReload(pd.Spec.ReloadAction) {
+	if !dynamicUpdated || !supportsDynamicReload(&pd.Spec) {
 		confirmPrompt = restartConfirmPrompt
 	}
 	return confirmPrompt, nil

--- a/pkg/cmd/cluster/config_observer.go
+++ b/pkg/cmd/cluster/config_observer.go
@@ -140,7 +140,7 @@ func (r *configObserverOptions) printComponentConfigSpecsDescribe(rctx *Reconfig
 func (r *configObserverOptions) printComponentExplainConfigure(rctx *ReconfigureContext) error {
 	for _, pd := range rctx.ParametersDefs {
 		if rctx.ConfigRender != nil {
-			config := configctrl.GetComponentConfigDescription(&rctx.ConfigRender.Spec, pd.Spec.FileName)
+			config := configctrl.GetComponentConfigDescription(configDescriptions(rctx), pd.Spec.FileName)
 			if config != nil {
 				fmt.Println("template meta:")
 				printer.PrintLineWithTabSeparator(

--- a/pkg/cmd/cluster/config_ops.go
+++ b/pkg/cmd/cluster/config_ops.go
@@ -29,7 +29,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/client/clientset/versioned"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	configctrl "github.com/apecloud/kubeblocks/pkg/parameters"
-	cfgcm "github.com/apecloud/kubeblocks/pkg/parameters/configmanager"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -137,7 +136,7 @@ func (o *configOpsOptions) Validate() error {
 		return err
 	}
 
-	classifyParams, err := configctrl.ClassifyComponentParameters(o.KeyValues, rctx.ParametersDefs, rctx.Cmpd.Spec.Configs, tplObjs, rctx.ConfigRender)
+	classifyParams, err := configctrl.ClassifyComponentParameters(o.KeyValues, rctx.ParametersDefs, rctx.Cmpd.Spec.Configs, tplObjs, configDescriptions(rctx))
 	if err != nil {
 		return err
 	}
@@ -161,7 +160,7 @@ func (o *configOpsOptions) validateConfigParams(rctx *ReconfigureContext, classi
 	checkRestart := func(params map[string]*parametersv1alpha1.ParametersInFile) bool {
 		for file := range params {
 			match := func(pd *parametersv1alpha1.ParametersDefinition) bool {
-				return pd.Spec.FileName == file && cfgcm.IsSupportReload(pd.Spec.ReloadAction)
+				return pd.Spec.FileName == file && supportsDynamicReload(&pd.Spec)
 			}
 			if generics.FindFirstFunc(rctx.ParametersDefs, match) < 0 {
 				return true
@@ -173,7 +172,7 @@ func (o *configOpsOptions) validateConfigParams(rctx *ReconfigureContext, classi
 	transform := func(params map[string]*parametersv1alpha1.ParametersInFile) []core.ParamPairs {
 		var result []core.ParamPairs
 		for file, ps := range params {
-			configDescs := configctrl.GetComponentConfigDescriptions(&rctx.ConfigRender.Spec, file)
+			configDescs := configctrl.GetComponentConfigDescriptions(configDescriptions(rctx), file)
 			builder := configctrl.NewValueManager(rctx.ParametersDefs, configDescs)
 			updatedParams, _ := core.FromStringMap(ps.Parameters, builder.BuildValueTransformer(file))
 			result = append(result, core.ParamPairs{
@@ -186,7 +185,7 @@ func (o *configOpsOptions) validateConfigParams(rctx *ReconfigureContext, classi
 
 	restart := false
 	for _, parameters := range classifyParameters {
-		_, err := configctrl.MergeAndValidateConfigs(mockEmptyData(parameters), transform(parameters), rctx.ParametersDefs, rctx.ConfigRender.Spec.Configs)
+		_, err := configctrl.MergeAndValidateConfigs(mockEmptyData(parameters), transform(parameters), rctx.ParametersDefs, configDescriptions(rctx))
 		if err != nil {
 			return err
 		}
@@ -207,6 +206,16 @@ func mockEmptyData(m map[string]*parametersv1alpha1.ParametersInFile) map[string
 		r[key] = ""
 	}
 	return r
+}
+
+func supportsDynamicReload(pd *parametersv1alpha1.ParametersDefinitionSpec) bool {
+	if pd == nil {
+		return false
+	}
+	if configctrl.NeedDynamicReloadAction(pd) {
+		return true
+	}
+	return pd.ReloadAction != nil && (pd.ReloadAction.AutoTrigger != nil || pd.ReloadAction.ShellTrigger != nil)
 }
 
 func fromStringPointerMap(m map[string]string) map[string]*string {

--- a/pkg/cmd/cluster/config_ops.go
+++ b/pkg/cmd/cluster/config_ops.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/client/clientset/versioned"
@@ -157,40 +158,28 @@ func (o *configOpsOptions) validateConfigParams(rctx *ReconfigureContext, classi
 		return o.confirmReconfigureWithRestart()
 	}
 
-	checkRestart := func(params map[string]*parametersv1alpha1.ParametersInFile) bool {
+	checkRestart := func(templateName string, params map[string]*parametersv1alpha1.ParametersInFile) bool {
+		template := componentFileTemplate(rctx, templateName)
 		for file := range params {
-			match := func(pd *parametersv1alpha1.ParametersDefinition) bool {
-				return pd.Spec.FileName == file && supportsDynamicReload(&pd.Spec)
-			}
-			if generics.FindFirstFunc(rctx.ParametersDefs, match) < 0 {
+			if !fileSupportsDynamicReload(rctx.ParametersDefs, file, template) {
 				return true
 			}
 		}
 		return false
 	}
 
-	transform := func(params map[string]*parametersv1alpha1.ParametersInFile) []core.ParamPairs {
-		var result []core.ParamPairs
-		for file, ps := range params {
-			configDescs := configctrl.GetComponentConfigDescriptions(configDescriptions(rctx), file)
-			builder := configctrl.NewValueManager(rctx.ParametersDefs, configDescs)
-			updatedParams, _ := core.FromStringMap(ps.Parameters, builder.BuildValueTransformer(file))
-			result = append(result, core.ParamPairs{
-				Key:           file,
-				UpdatedParams: updatedParams,
-			})
-		}
-		return result
-	}
-
 	restart := false
-	for _, parameters := range classifyParameters {
-		_, err := configctrl.MergeAndValidateConfigs(mockEmptyData(parameters), transform(parameters), rctx.ParametersDefs, configDescriptions(rctx))
+	for templateName, parameters := range classifyParameters {
+		paramPairs, err := transformConfigParams(rctx, templateName, parameters)
+		if err != nil {
+			return err
+		}
+		_, err = configctrl.MergeAndValidateConfigs(mockEmptyData(parameters), paramPairs, rctx.ParametersDefs, configDescriptions(rctx))
 		if err != nil {
 			return err
 		}
 		if !restart {
-			restart = checkRestart(parameters)
+			restart = checkRestart(templateName, parameters)
 		}
 	}
 
@@ -208,12 +197,51 @@ func mockEmptyData(m map[string]*parametersv1alpha1.ParametersInFile) map[string
 	return r
 }
 
-func supportsDynamicReload(pd *parametersv1alpha1.ParametersDefinitionSpec) bool {
+func transformConfigParams(rctx *ReconfigureContext, templateName string, params map[string]*parametersv1alpha1.ParametersInFile) ([]core.ParamPairs, error) {
+	var result []core.ParamPairs
+	configDescs := configctrl.GetComponentConfigDescriptions(configDescriptions(rctx), templateName)
+	builder := configctrl.NewValueManager(rctx.ParametersDefs, configDescs)
+	for file, ps := range params {
+		updatedParams, err := core.FromStringMap(ps.Parameters, builder.BuildValueTransformer(file))
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, core.ParamPairs{
+			Key:           file,
+			UpdatedParams: updatedParams,
+		})
+	}
+	return result, nil
+}
+
+func componentFileTemplate(rctx *ReconfigureContext, templateName string) *kbappsv1.ComponentFileTemplate {
+	if rctx == nil || rctx.Cmpd == nil {
+		return nil
+	}
+	for i := range rctx.Cmpd.Spec.Configs {
+		if rctx.Cmpd.Spec.Configs[i].Name == templateName {
+			return &rctx.Cmpd.Spec.Configs[i]
+		}
+	}
+	return nil
+}
+
+func fileSupportsDynamicReload(paramsDefs []*parametersv1alpha1.ParametersDefinition, file string, template *kbappsv1.ComponentFileTemplate) bool {
+	if supportsDynamicReload(nil, template) {
+		return true
+	}
+	match := func(pd *parametersv1alpha1.ParametersDefinition) bool {
+		return pd.Spec.FileName == file && supportsDynamicReload(&pd.Spec, nil)
+	}
+	return generics.FindFirstFunc(paramsDefs, match) >= 0
+}
+
+func supportsDynamicReload(pd *parametersv1alpha1.ParametersDefinitionSpec, template *kbappsv1.ComponentFileTemplate) bool {
+	if template != nil && template.Reconfigure != nil {
+		return true
+	}
 	if pd == nil {
 		return false
-	}
-	if configctrl.NeedDynamicReloadAction(pd) {
-		return true
 	}
 	return pd.ReloadAction != nil && (pd.ReloadAction.AutoTrigger != nil || pd.ReloadAction.ShellTrigger != nil)
 }

--- a/pkg/cmd/cluster/config_ops_test.go
+++ b/pkg/cmd/cluster/config_ops_test.go
@@ -33,6 +33,7 @@ import (
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	kbfakeclient "github.com/apecloud/kubeblocks/pkg/client/clientset/versioned/fake"
 	cfgcore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -118,6 +119,21 @@ var _ = Describe("reconfigure test", func() {
 
 		o.CreateOptions.In = io.NopCloser(in)
 		Expect(o.Validate()).Should(Succeed())
+	})
+
+	It("detects v1.2 and legacy dynamic reload support", func() {
+		mergeReloadAndRestart := false
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{
+			MergeReloadAndRestart: &mergeReloadAndRestart,
+		})).Should(BeTrue())
+
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{
+			ReloadAction: &parametersv1alpha1.ReloadAction{
+				ShellTrigger: &parametersv1alpha1.ShellTrigger{},
+			},
+		})).Should(BeTrue())
+
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{})).Should(BeFalse())
 	})
 
 })

--- a/pkg/cmd/cluster/config_ops_test.go
+++ b/pkg/cmd/cluster/config_ops_test.go
@@ -21,6 +21,7 @@ package cluster
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -83,6 +84,8 @@ var _ = Describe("reconfigure test", func() {
 		configmap := testapps.NewCustomizedObj("resources/mysql-config-template.yaml", &corev1.ConfigMap{}, testapps.WithNamespace(ns), testapps.WithName(testing.FakeMysqlTemplateName))
 		componentConfig := testapps.NewConfigMap(ns, cfgcore.GetComponentCfgName(clusterName, statefulCompName, configSpecName), setConfigMapData("my.cnf", ""))
 		objs := []runtime.Object{configmap, componentConfig}
+		pd := testing.FakeParameterDefinition()
+		pd.Status = parametersv1alpha1.ParametersDefinitionStatus{Phase: parametersv1alpha1.PDAvailablePhase}
 		ttf, ops := NewFakeOperationsOptions(ns, clusterName, objs...)
 		o := &configOpsOptions{
 			// nil cannot be set to a map struct in CueLang, so init the map of KeyValues.
@@ -95,7 +98,7 @@ var _ = Describe("reconfigure test", func() {
 		o.clientSet = kbfakeclient.NewSimpleClientset(
 			testing.FakeCluster(clusterName, ns),
 			testing.FakeCompDef(),
-			testing.FakeParameterDefinition(),
+			pd,
 			testing.FakeParameterConfigRenderer(),
 		)
 		defer ttf.Cleanup()
@@ -139,6 +142,135 @@ var _ = Describe("reconfigure test", func() {
 		}, nil)).Should(BeTrue())
 
 		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{}, nil)).Should(BeFalse())
+	})
+
+	It("discovers direct ParametersDefinitions without legacy ParamConfigRenderer", func() {
+		pd := testing.FakeParameterDefinition()
+		pd.Name = "direct-pd"
+		pd.Spec.ComponentDef = testing.CompDefName
+		pd.Spec.TemplateName = "mysql-config"
+		pd.Spec.FileName = "my.cnf"
+		pd.Spec.FileFormatConfig = &parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.Ini}
+		pd.Status = parametersv1alpha1.ParametersDefinitionStatus{Phase: parametersv1alpha1.PDAvailablePhase}
+
+		rctx, err := generateReconfigureContext(
+			context.TODO(),
+			kbfakeclient.NewSimpleClientset(
+				testing.FakeCluster(clusterName, testing.Namespace),
+				testing.FakeCompDef(),
+				pd,
+			),
+			clusterName,
+			testing.ComponentName,
+			testing.Namespace,
+		)
+
+		Expect(err).Should(Succeed())
+		Expect(rctx.ParametersDefs).Should(HaveLen(1))
+		Expect(rctx.ParametersDefs[0].Name).Should(Equal("direct-pd"))
+		Expect(configDescriptions(rctx)).Should(Equal([]parametersv1alpha1.ComponentConfigDescription{{
+			Name:         "my.cnf",
+			TemplateName: "mysql-config",
+			FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+				Format: parametersv1alpha1.Ini,
+			},
+		}}))
+		Expect(rctx.ConfigRender).Should(BeNil())
+	})
+
+	It("keeps legacy ParamConfigRenderer discovery with component definition pattern matching", func() {
+		pd := testing.FakeParameterDefinition()
+		pd.Status = parametersv1alpha1.ParametersDefinitionStatus{Phase: parametersv1alpha1.PDAvailablePhase}
+		pcr := testing.FakeParameterConfigRenderer()
+		pcr.Spec.ComponentDef = "fake-component"
+
+		rctx, err := generateReconfigureContext(
+			context.TODO(),
+			kbfakeclient.NewSimpleClientset(
+				testing.FakeCluster(clusterName, testing.Namespace),
+				testing.FakeCompDef(),
+				pd,
+				pcr,
+			),
+			clusterName,
+			testing.ComponentName,
+			testing.Namespace,
+		)
+
+		Expect(err).Should(Succeed())
+		Expect(rctx.ParametersDefs).Should(HaveLen(1))
+		Expect(rctx.ParametersDefs[0].Name).Should(Equal("test-pd"))
+		Expect(configDescriptions(rctx)).Should(Equal(pcr.Spec.Configs))
+		Expect(rctx.ConfigRender).ShouldNot(BeNil())
+	})
+
+	It("merges direct ParametersDefinitions with legacy ParamConfigRenderer for uncovered files", func() {
+		directPD := testing.FakeParameterDefinition()
+		directPD.Name = "direct-pd"
+		directPD.Spec.ComponentDef = testing.CompDefName
+		directPD.Spec.TemplateName = "mysql-config"
+		directPD.Spec.FileName = "my.cnf"
+		directPD.Spec.FileFormatConfig = &parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.Ini}
+		directPD.Status = parametersv1alpha1.ParametersDefinitionStatus{Phase: parametersv1alpha1.PDAvailablePhase}
+
+		legacyPD := testing.FakeParameterDefinition()
+		legacyPD.Name = "legacy-pd"
+		legacyPD.Spec.FileName = "log.conf"
+		legacyPD.Status = parametersv1alpha1.ParametersDefinitionStatus{Phase: parametersv1alpha1.PDAvailablePhase}
+
+		pcr := testing.FakeParameterConfigRenderer()
+		pcr.Spec.ParametersDefs = []string{"direct-pd", "legacy-pd"}
+		pcr.Spec.Configs = []parametersv1alpha1.ComponentConfigDescription{
+			{
+				Name:         "my.cnf",
+				TemplateName: "legacy-mysql-config",
+				FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+					Format: parametersv1alpha1.Properties,
+				},
+			},
+			{
+				Name:         "log.conf",
+				TemplateName: "log-config",
+				FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+					Format: parametersv1alpha1.Properties,
+				},
+			},
+		}
+
+		rctx, err := generateReconfigureContext(
+			context.TODO(),
+			kbfakeclient.NewSimpleClientset(
+				testing.FakeCluster(clusterName, testing.Namespace),
+				testing.FakeCompDef(),
+				directPD,
+				legacyPD,
+				pcr,
+			),
+			clusterName,
+			testing.ComponentName,
+			testing.Namespace,
+		)
+
+		Expect(err).Should(Succeed())
+		Expect(rctx.ParametersDefs).Should(HaveLen(2))
+		Expect(rctx.ParametersDefs[0].Name).Should(Equal("direct-pd"))
+		Expect(rctx.ParametersDefs[1].Name).Should(Equal("legacy-pd"))
+		Expect(configDescriptions(rctx)).Should(Equal([]parametersv1alpha1.ComponentConfigDescription{
+			{
+				Name:         "my.cnf",
+				TemplateName: "mysql-config",
+				FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+					Format: parametersv1alpha1.Ini,
+				},
+			},
+			{
+				Name:         "log.conf",
+				TemplateName: "log-config",
+				FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+					Format: parametersv1alpha1.Properties,
+				},
+			},
+		}))
 	})
 
 	It("uses config template name to transform typed parameter values", func() {

--- a/pkg/cmd/cluster/config_ops_test.go
+++ b/pkg/cmd/cluster/config_ops_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	clientfake "k8s.io/client-go/rest/fake"
@@ -125,15 +126,67 @@ var _ = Describe("reconfigure test", func() {
 		mergeReloadAndRestart := false
 		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{
 			MergeReloadAndRestart: &mergeReloadAndRestart,
+		}, nil)).Should(BeFalse())
+
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{}, &kbappsv1.ComponentFileTemplate{
+			Reconfigure: &kbappsv1.Action{},
 		})).Should(BeTrue())
 
 		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{
 			ReloadAction: &parametersv1alpha1.ReloadAction{
 				ShellTrigger: &parametersv1alpha1.ShellTrigger{},
 			},
-		})).Should(BeTrue())
+		}, nil)).Should(BeTrue())
 
-		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{})).Should(BeFalse())
+		Expect(supportsDynamicReload(&parametersv1alpha1.ParametersDefinitionSpec{}, nil)).Should(BeFalse())
+	})
+
+	It("uses config template name to transform typed parameter values", func() {
+		value := "true"
+		params := map[string]*parametersv1alpha1.ParametersInFile{
+			"my.cnf": {
+				Parameters: map[string]*string{
+					"enabled": &value,
+				},
+			},
+		}
+		rctx := &ReconfigureContext{
+			ConfigRender: &parametersv1alpha1.ParamConfigRenderer{
+				Spec: parametersv1alpha1.ParamConfigRendererSpec{
+					Configs: []parametersv1alpha1.ComponentConfigDescription{{
+						Name:         "my.cnf",
+						TemplateName: "mysql-config",
+						FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+							Format: parametersv1alpha1.JSON,
+						},
+					}},
+				},
+			},
+			ParametersDefs: []*parametersv1alpha1.ParametersDefinition{{
+				Spec: parametersv1alpha1.ParametersDefinitionSpec{
+					FileName: "my.cnf",
+					ParametersSchema: &parametersv1alpha1.ParametersSchema{
+						SchemaInJSON: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"enabled": {Type: "boolean"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		}
+
+		result, err := transformConfigParams(rctx, "mysql-config", params)
+		Expect(err).Should(Succeed())
+		Expect(result).Should(HaveLen(1))
+		Expect(result[0].Key).Should(Equal("my.cnf"))
+		Expect(result[0].UpdatedParams["enabled"]).Should(BeTrue())
 	})
 
 })

--- a/pkg/cmd/cluster/config_wrapper.go
+++ b/pkg/cmd/cluster/config_wrapper.go
@@ -23,10 +23,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/client/clientset/versioned"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	configctrl "github.com/apecloud/kubeblocks/pkg/parameters"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +43,7 @@ type ReconfigureContext struct {
 	Cluster        *kbappsv1.Cluster
 	Cmpd           *kbappsv1.ComponentDefinition
 	ConfigRender   *parametersv1alpha1.ParamConfigRenderer
+	ConfigDescs    []parametersv1alpha1.ComponentConfigDescription
 	ParametersDefs []*parametersv1alpha1.ParametersDefinition
 
 	CompName string
@@ -60,7 +64,7 @@ func (w *ReconfigureWrapper) ConfigSpecName() string {
 		return w.configFileKey
 	}
 	file := w.ConfigFile()
-	if file != "" && w.rctx.ConfigRender != nil {
+	if file != "" {
 		config := configctrl.GetComponentConfigDescription(configDescriptions(w.rctx), file)
 		if config != nil {
 			return config.TemplateName
@@ -77,14 +81,20 @@ func (w *ReconfigureWrapper) ConfigFile() string {
 	if w.configFileKey != "" {
 		return w.configFileKey
 	}
-	if w.rctx.ConfigRender != nil && len(w.rctx.ConfigRender.Spec.Configs) > 0 {
-		return w.rctx.ConfigRender.Spec.Configs[0].Name
+	if configDescs := configDescriptions(w.rctx); len(configDescs) > 0 {
+		return configDescs[0].Name
 	}
 	return ""
 }
 
 func configDescriptions(rctx *ReconfigureContext) []parametersv1alpha1.ComponentConfigDescription {
-	if rctx == nil || rctx.ConfigRender == nil {
+	if rctx == nil {
+		return nil
+	}
+	if len(rctx.ConfigDescs) > 0 {
+		return rctx.ConfigDescs
+	}
+	if rctx.ConfigRender == nil {
 		return nil
 	}
 	return rctx.ConfigRender.Spec.Configs
@@ -191,20 +201,117 @@ func resolveComponentDefObj(ctx context.Context, client versioned.Interface, clu
 }
 
 func resolveCmpdParametersDefs(rctx *ReconfigureContext) error {
+	configDescs, paramsDefs, coveredFiles, err := resolveDirectParametersDefs(rctx)
+	if err != nil {
+		return err
+	}
+
 	configRender, err := resolveComponentConfigRender(rctx, rctx.Cmpd)
 	if err != nil {
 		return err
 	}
-	if configRender == nil || len(configRender.Spec.ParametersDefs) == 0 {
-		return nil
-	}
 	rctx.ConfigRender = configRender
-	for _, defName := range configRender.Spec.ParametersDefs {
-		pd, err := rctx.Client.ParametersV1alpha1().ParametersDefinitions().Get(rctx.Context, defName, metav1.GetOptions{})
-		if err != nil {
-			return err
+	if configRender != nil {
+		legacyConfigFiles := make(map[string]struct{}, len(configRender.Spec.Configs))
+		for _, configDesc := range configRender.Spec.Configs {
+			if _, ok := coveredFiles[configDesc.Name]; ok {
+				continue
+			}
+			configDescs = append(configDescs, configDesc)
+			legacyConfigFiles[configDesc.Name] = struct{}{}
 		}
-		rctx.ParametersDefs = append(rctx.ParametersDefs, pd)
+		for _, defName := range configRender.Spec.ParametersDefs {
+			pd, err := rctx.Client.ParametersV1alpha1().ParametersDefinitions().Get(rctx.Context, defName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if pd.Status.Phase != parametersv1alpha1.PDAvailablePhase {
+				return fmt.Errorf("the referenced ParametersDefinition is unavailable: %s", pd.Name)
+			}
+			if _, ok := legacyConfigFiles[pd.Spec.FileName]; ok {
+				paramsDefs = append(paramsDefs, pd)
+			}
+		}
+	}
+
+	rctx.ConfigDescs = configDescs
+	rctx.ParametersDefs = paramsDefs
+	return nil
+}
+
+func resolveDirectParametersDefs(rctx *ReconfigureContext) ([]parametersv1alpha1.ComponentConfigDescription, []*parametersv1alpha1.ParametersDefinition, map[string]struct{}, error) {
+	paramsDefList, err := rctx.Client.ParametersV1alpha1().ParametersDefinitions().List(rctx.Context, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	slices.SortFunc(paramsDefList.Items, func(a, b parametersv1alpha1.ParametersDefinition) int {
+		if cmp := strings.Compare(b.Spec.ComponentDef, a.Spec.ComponentDef); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.Spec.TemplateName, b.Spec.TemplateName); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.Spec.FileName, b.Spec.FileName); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	var paramsDefs []*parametersv1alpha1.ParametersDefinition
+	configDescs := make([]parametersv1alpha1.ComponentConfigDescription, 0, len(paramsDefList.Items))
+	coveredFiles := make(map[string]struct{})
+	for i := range paramsDefList.Items {
+		paramsDef := &paramsDefList.Items[i]
+		matched, err := matchParametersDefinition(rctx.Cmpd, paramsDef)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if !matched {
+			continue
+		}
+		if paramsDef.Status.Phase != parametersv1alpha1.PDAvailablePhase {
+			return nil, nil, nil, fmt.Errorf("the referenced ParametersDefinition is unavailable: %s", paramsDef.Name)
+		}
+		if err := validateMatchedParametersDefinition(paramsDef); err != nil {
+			return nil, nil, nil, err
+		}
+		if _, ok := coveredFiles[paramsDef.Spec.FileName]; ok {
+			return nil, nil, nil, fmt.Errorf("config file[%s] has been defined in other parametersdefinition", paramsDef.Spec.FileName)
+		}
+		coveredFiles[paramsDef.Spec.FileName] = struct{}{}
+		paramsDefs = append(paramsDefs, paramsDef)
+		configDescs = append(configDescs, parametersv1alpha1.ComponentConfigDescription{
+			Name:             paramsDef.Spec.FileName,
+			TemplateName:     paramsDef.Spec.TemplateName,
+			FileFormatConfig: paramsDef.Spec.FileFormatConfig.DeepCopy(),
+		})
+	}
+	return configDescs, paramsDefs, coveredFiles, nil
+}
+
+func matchParametersDefinition(cmpd *kbappsv1.ComponentDefinition, paramsDef *parametersv1alpha1.ParametersDefinition) (bool, error) {
+	if cmpd == nil || paramsDef == nil {
+		return false, nil
+	}
+	pattern := paramsDef.Spec.ComponentDef
+	if pattern == "" {
+		return false, nil
+	}
+	if !component.PrefixOrRegexMatched(cmpd.Name, pattern) {
+		return false, nil
+	}
+	return paramsDef.Spec.ServiceVersion == "" || paramsDef.Spec.ServiceVersion == cmpd.Spec.ServiceVersion, nil
+}
+
+func validateMatchedParametersDefinition(paramsDef *parametersv1alpha1.ParametersDefinition) error {
+	if paramsDef.Spec.TemplateName == "" {
+		return fmt.Errorf("ParametersDefinition[%s] misses templateName", paramsDef.Name)
+	}
+	if paramsDef.Spec.FileName == "" {
+		return fmt.Errorf("ParametersDefinition[%s] misses fileName", paramsDef.Name)
+	}
+	if paramsDef.Spec.FileFormatConfig == nil {
+		return fmt.Errorf("ParametersDefinition[%s] misses fileFormatConfig", paramsDef.Name)
 	}
 	return nil
 }
@@ -217,7 +324,7 @@ func resolveComponentConfigRender(rctx *ReconfigureContext, cmpd *kbappsv1.Compo
 
 	var prcs []parametersv1alpha1.ParamConfigRenderer
 	for i, item := range pcrList.Items {
-		if item.Spec.ComponentDef != cmpd.Name {
+		if !component.PrefixOrRegexMatched(cmpd.Name, item.Spec.ComponentDef) {
 			continue
 		}
 		if item.Spec.ServiceVersion == "" || item.Spec.ServiceVersion == cmpd.Spec.ServiceVersion {

--- a/pkg/cmd/cluster/config_wrapper.go
+++ b/pkg/cmd/cluster/config_wrapper.go
@@ -61,7 +61,7 @@ func (w *ReconfigureWrapper) ConfigSpecName() string {
 	}
 	file := w.ConfigFile()
 	if file != "" && w.rctx.ConfigRender != nil {
-		config := configctrl.GetComponentConfigDescription(&w.rctx.ConfigRender.Spec, file)
+		config := configctrl.GetComponentConfigDescription(configDescriptions(w.rctx), file)
 		if config != nil {
 			return config.TemplateName
 		}
@@ -81,6 +81,13 @@ func (w *ReconfigureWrapper) ConfigFile() string {
 		return w.rctx.ConfigRender.Spec.Configs[0].Name
 	}
 	return ""
+}
+
+func configDescriptions(rctx *ReconfigureContext) []parametersv1alpha1.ComponentConfigDescription {
+	if rctx == nil || rctx.ConfigRender == nil {
+		return nil
+	}
+	return rctx.ConfigRender.Spec.Configs
 }
 
 func GetClientFromOptionsOrDie(factory cmdutil.Factory) versioned.Interface {


### PR DESCRIPTION
- fix https://github.com/apecloud/kubeblocks/issues/10370
## Summary
- upgrade github.com/apecloud/kubeblocks to v1.2.0-alpha.2
- adapt cluster config/reconfigure code to the v1.2 parameters API
- preserve legacy reload-action handling while supporting v1.2 dynamic reload metadata

## Root cause
KubeBlocks v1.2 changed Cluster config fields such as configs[].reconfigure to booleans and removed the old pkg/parameters/configmanager package. kbcli needed to consume the new API shape and replace the removed helper usage.

## Validation
- GOCACHE=/private/tmp/kbcli-go-build-cache go test ./pkg/cmd/cluster -count=1
- GOCACHE=/private/tmp/kbcli-go-build-cache go test ./pkg/... -count=1
- GOCACHE=/private/tmp/kbcli-go-build-cache go build -o /private/tmp/kbcli-v12 ./cmd/cli
- KUBECONFIG=/Users/shanshan/.kube/cloud-kb10-config /private/tmp/kbcli-v12 cluster list-instances -n demo
- KUBECONFIG=/Users/shanshan/.kube/cloud-kb10-config /private/tmp/kbcli-v12 cluster list mysql-cluster -n demo