### PR TITLE
chore: respect namespace in report cluster

### DIFF
--- a/pkg/cmd/cluster/create_subcmds_test.go
+++ b/pkg/cmd/cluster/create_subcmds_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
@@ -164,7 +165,34 @@ var _ = Describe("create cluster by cluster type", func() {
 		Expect(o.Complete(shardCmd)).Should(Succeed())
 		Expect(o.Name).ShouldNot(BeEmpty())
 		Expect(o.Values).ShouldNot(BeNil())
-		Expect(o.ChartInfo.ComponentDef[0]).Should(Equal(redisComponent))
+		Expect(o.ChartInfo.ClusterDef).Should(Equal(redisCluster))
+		hasRedisComponentDef := false
+		for _, componentDef := range o.ChartInfo.ComponentDef {
+			if componentDef == redisComponent {
+				hasRedisComponentDef = true
+				break
+			}
+		}
+		objs, err := o.getObjectsInfo()
+		Expect(err).ShouldNot(HaveOccurred())
+		clusterObj, err := o.getClusterObj(objs)
+		Expect(err).ShouldNot(HaveOccurred())
+		hasShardingDef := false
+		shardings, ok, err := unstructured.NestedSlice(clusterObj.Object, "spec", "shardings")
+		Expect(err).ShouldNot(HaveOccurred())
+		if ok {
+			for _, item := range shardings {
+				shardingSpec, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if shardingDef, ok := shardingSpec["shardingDef"].(string); ok && shardingDef != "" {
+					hasShardingDef = true
+					break
+				}
+			}
+		}
+		Expect(hasShardingDef || hasRedisComponentDef).Should(BeTrue(), "redis sharding chart should set either shardingDef or componentDef")
 
 		By("validate")
 		o.Dynamic = testing.FakeDynamicClient()

--- a/pkg/cmd/report/report.go
+++ b/pkg/cmd/report/report.go
@@ -437,10 +437,12 @@ func (o *reportClusterOptions) complete(f cmdutil.Factory) error {
 	if err := o.reportOptions.complete(f); err != nil {
 		return err
 	}
-	// update namespace
-	o.namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil {
-		return err
+	// update namespace if not specified
+	if o.namespace == "" {
+		o.namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return err
+		}
 	}
 	// complete file name
 

--- a/pkg/cmd/report/report_test.go
+++ b/pkg/cmd/report/report_test.go
@@ -452,6 +452,14 @@ var _ = Describe("report", func() {
 			Expect(o.file).Should(MatchRegexp("report-cluster-.*.zip"))
 		})
 
+		It("complete cluster-report options should respect specified namespace", func() {
+			o := reportClusterOptions{reportOptions: newReportOptions(streams)}
+			o.outputFormat = jsonFormat
+			o.namespace = "demo"
+			Expect(o.complete(tf)).To(Succeed())
+			Expect(o.namespace).Should(Equal("demo"))
+		})
+
 		It("handle cluster-report manifests", func() {
 			o := reportClusterOptions{reportOptions: newReportOptions(streams)}
 			o.outputFormat = jsonFormat


### PR DESCRIPTION
## Summary

- Backport the report cluster namespace fix from PR #613 to release-1.0.
- Preserve the namespace passed by `-n/--namespace` instead of overwriting it with the current kubeconfig namespace.
- Add a regression test for the explicit namespace case.

## Validation

- `GOCACHE=/private/tmp/kbcli-go-test-cache-release10 go test ./pkg/cmd/report -count=1`
