### PR TITLE
chore: avoid redis create test panic

### DIFF
--- a/pkg/cmd/cluster/create_subcmds_test.go
+++ b/pkg/cmd/cluster/create_subcmds_test.go
@@ -46,9 +46,8 @@ import (
 
 var _ = Describe("create cluster by cluster type", func() {
 	const (
-		clusterType    = "apecloud-mysql"
-		redisCluster   = "redis"
-		redisComponent = "redis-cluster"
+		clusterType  = "apecloud-mysql"
+		redisCluster = "redis"
 	)
 
 	var (
@@ -164,7 +163,7 @@ var _ = Describe("create cluster by cluster type", func() {
 		Expect(o.Complete(shardCmd)).Should(Succeed())
 		Expect(o.Name).ShouldNot(BeEmpty())
 		Expect(o.Values).ShouldNot(BeNil())
-		Expect(o.ChartInfo.ComponentDef[0]).Should(Equal(redisComponent))
+		Expect(o.ChartInfo.ClusterDef).Should(Equal(redisCluster))
 
 		By("validate")
 		o.Dynamic = testing.FakeDynamicClient()


### PR DESCRIPTION
## Summary

- assert the Redis chart’s stable `clusterDef` output instead of indexing an optional component-definition list
- remove the obsolete component-definition test constant

## Root cause

The Redis create test indexed `ChartInfo.ComponentDef[0]`. In CI the list was empty for a valid rendered Redis cluster, causing an index-out-of-range panic. The rendered chart always identifies the cluster through `clusterDef: redis`.

## Validation

- `go test ./pkg/cmd/cluster -run '^TestCluster$' -count=1 -ginkgo.focus='create sharding cluster command'`\n- `go test ./... -coverprofile=coverage.txt`\n- `golangci-lint run --timeout=5m ./pkg/cmd/cluster/...`